### PR TITLE
#34: Add custom playground URL support

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -31,5 +31,5 @@ COPY --from=build /tmp/playground/server .
 COPY --from=build /tmp/playground/worker.wasm ./public
 COPY --from=build /tmp/playground/wasm_exec.js ./public
 EXPOSE 8000
-ENTRYPOINT /opt/playground/server -f=/opt/playground/data/packages.json -addr=:8000\
+ENTRYPOINT /opt/playground/server -f=/opt/playground/data/packages.json -addr=:8000 \
   -clean-interval=${APP_CLEAN_INTERVAL} -debug=${APP_DEBUG} -playground-url=${APP_PLAYGROUND_URL}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,10 +24,12 @@ WORKDIR /opt/playground
 ENV GOROOT /usr/local/go
 ENV APP_CLEAN_INTERVAL=10m
 ENV APP_DEBUG=false
+ENV APP_PLAYGROUND_URL=https://play.golang.org
 COPY data ./data
 COPY --from=ui-build /tmp/web/build ./public
 COPY --from=build /tmp/playground/server .
 COPY --from=build /tmp/playground/worker.wasm ./public
 COPY --from=build /tmp/playground/wasm_exec.js ./public
 EXPOSE 8000
-ENTRYPOINT /opt/playground/server -f=/opt/playground/data/packages.json -addr=:8000 -clean-interval=${APP_CLEAN_INTERVAL} -debug=${APP_DEBUG}
+ENTRYPOINT /opt/playground/server -f=/opt/playground/data/packages.json -addr=:8000\
+  -clean-interval=${APP_CLEAN_INTERVAL} -debug=${APP_DEBUG} -playground-url=${APP_PLAYGROUND_URL}

--- a/pkg/goplay/client.go
+++ b/pkg/goplay/client.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	defaultUserAgent = "goplay.tools/1.0 (http://goplay.tools/)"
-	playgroundUrl    = "https://play.golang.org"
+	DefaultUserAgent     = "goplay.tools/1.0 (http://goplay.tools/)"
+	DefaultPlaygroundURL = "https://play.golang.org"
 
 	// maxSnippetSize value taken from
 	// https://github.com/golang/playground/blob/master/app/goplay/share.go
@@ -50,7 +50,7 @@ func NewClient(baseUrl, userAgent string, timeout time.Duration) *Client {
 
 // NewDefaultClient returns Go Playground client with defaults
 func NewDefaultClient() *Client {
-	return NewClient(playgroundUrl, defaultUserAgent, 15*time.Second)
+	return NewClient(DefaultPlaygroundURL, DefaultUserAgent, 15*time.Second)
 }
 
 func (c *Client) newRequest(ctx context.Context, method, queryPath string, body io.Reader) (*http.Request, error) {

--- a/pkg/goplay/client_test.go
+++ b/pkg/goplay/client_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestNewDefaultClient(t *testing.T) {
 	c := NewDefaultClient()
-	require.Equal(t, c.baseUrl, playgroundUrl)
-	require.Equal(t, c.userAgent, defaultUserAgent)
+	require.Equal(t, c.baseUrl, DefaultPlaygroundURL)
+	require.Equal(t, c.userAgent, DefaultUserAgent)
 }

--- a/pkg/langserver/server.go
+++ b/pkg/langserver/server.go
@@ -39,11 +39,11 @@ type Service struct {
 }
 
 // New is Service constructor
-func New(version string, packages []*analyzer.Package, builder compiler.BuildService) *Service {
+func New(version string, playground *goplay.Client, packages []*analyzer.Package, builder compiler.BuildService) *Service {
 	return &Service{
 		compiler:   builder,
 		version:    version,
-		playground: goplay.NewDefaultClient(),
+		playground: playground,
 		log:        zap.S().Named("langserver"),
 		index:      analyzer.BuildPackageIndex(packages),
 		limiter:    rate.NewLimiter(rate.Every(frameTime), compileRequestsPerFrame),


### PR DESCRIPTION
Allow to use custom playground URL with `-playground-url` argument, or with `APP_PLAYGROUND_URL` environment variable for Docker image.

Closes #34  