### PR TITLE
web: hide text in "whats new" button

### DIFF
--- a/web/src/components/core/Header.tsx
+++ b/web/src/components/core/Header.tsx
@@ -161,6 +161,7 @@ export class Header extends React.Component<any, HeaderState> {
         key: 'changelog',
         text: 'What\'s new',
         ariaLabel: 'Changelog',
+        iconOnly: true,
         disabled: this.props.loading,
         iconProps: { iconName: 'Giftbox' },
         onClick: () => {


### PR DESCRIPTION
Hide text in "Whats new" button to keep more free space (especially for small phone screens)