### PR TITLE
ci: use new env var syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Set release version
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/v}
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
       - name: Build Docker image
         run: |
           make docker-image TAG=${{ env.RELEASE_VERSION }} GTAG=${{ secrets.GTAG }}


### PR DESCRIPTION
Recently, GitHub Actions [changed a way to declare environment variables](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) which breaks our release process.

This PR fixes this by using a new way to set environment variables.

**Before (broken):**

```yaml
      - name: Set release version
        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/v}
```

**New way (correct):**

```yaml
      - name: Set release version
        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
```