### PR TITLE
web: add snippers for panic, recover and defer

### DIFF
--- a/web/src/services/go/snippets.json
+++ b/web/src/services/go/snippets.json
@@ -47,6 +47,14 @@
     {
       "label": "Errors",
       "snippet": "NiJOpCPO3L0"
+    },
+    {
+      "label": "Defer",
+      "snippet": "5SDVfc_jxbg"
+    },
+    {
+      "label": "Panic & recover",
+      "snippet": "Sk-SVdofEIZ"
     }
   ],
   "Concurrency": [


### PR DESCRIPTION
Add snippets for [defer](https://gobyexample.com/defer) and [panic+recover](https://gobyexample.com/recover).

Closes #102 

<img width="250" alt="image" src="https://user-images.githubusercontent.com/9203548/157575771-ea8c38d4-b927-47df-a2d0-be08f5a3c8cc.png">
