### PR TITLE
Add GoTip playground backend support

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,7 +24,8 @@ WORKDIR /opt/playground
 ENV GOROOT /usr/local/go
 ENV APP_CLEAN_INTERVAL=10m
 ENV APP_DEBUG=false
-ENV APP_PLAYGROUND_URL=https://play.golang.org
+ENV APP_PLAYGROUND_URL='https://play.golang.org'
+ENV APP_GOTIP_URL='https://gotipplay.golang.org'
 COPY data ./data
 COPY --from=ui-build /tmp/web/build ./public
 COPY --from=build /tmp/playground/server .
@@ -32,4 +33,4 @@ COPY --from=build /tmp/playground/worker.wasm ./public
 COPY --from=build /tmp/playground/wasm_exec.js ./public
 EXPOSE 8000
 ENTRYPOINT /opt/playground/server -f=/opt/playground/data/packages.json -addr=:8000 \
-    -clean-interval=${APP_CLEAN_INTERVAL} -debug=${APP_DEBUG} -playground-url=${APP_PLAYGROUND_URL}
+    -clean-interval=${APP_CLEAN_INTERVAL} -debug=${APP_DEBUG} -playground-url=${APP_PLAYGROUND_URL} -gotip-url=${APP_GOTIP_URL}

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -24,13 +24,15 @@ import (
 var Version = "testing"
 
 type appArgs struct {
-	packagesFile    string
-	playgroundUrl   string
-	addr            string
-	debug           bool
-	buildDir        string
-	cleanupInterval string
-	assetsDirectory string
+	packagesFile       string
+	playgroundURL      string
+	goTipPlaygroundURL string
+	addr               string
+	debug              bool
+	buildDir           string
+	cleanupInterval    string
+	assetsDirectory    string
+	connectTimeout     time.Duration
 }
 
 func (a appArgs) getCleanDuration() (time.Duration, error) {
@@ -49,9 +51,11 @@ func main() {
 	flag.StringVar(&args.addr, "addr", ":8080", "TCP Listen address")
 	flag.StringVar(&args.buildDir, "wasm-build-dir", os.TempDir(), "Directory for WASM builds")
 	flag.StringVar(&args.cleanupInterval, "clean-interval", "10m", "Build directory cleanup interval")
-	flag.StringVar(&args.playgroundUrl, "playground-url", goplay.DefaultPlaygroundURL, "Go Playground URL")
+	flag.StringVar(&args.playgroundURL, "playground-url", goplay.DefaultPlaygroundURL, "Go Playground URL")
+	flag.StringVar(&args.goTipPlaygroundURL, "gotip-playground-url", goplay.DefaultGoTipPlaygroundURL, "GoTip Playground URL")
 	flag.BoolVar(&args.debug, "debug", false, "Enable debug mode")
 	flag.StringVar(&args.assetsDirectory, "static-dir", filepath.Join(wd, "public"), "Path to web page assets (HTML, JS, etc)")
+	flag.DurationVar(&args.connectTimeout, "timeout", 15*time.Second, "Go Playground server connect timeout")
 
 	l := getLogger(args.debug)
 	defer l.Sync() //nolint:errcheck
@@ -92,7 +96,7 @@ func start(goRoot string, args appArgs) error {
 
 	zap.S().Info("Server version: ", Version)
 	zap.S().Infof("GOROOT is %q", goRoot)
-	zap.S().Infof("Playground url: %q", args.playgroundUrl)
+	zap.S().Infof("Playground url: %q", args.playgroundURL)
 	zap.S().Infof("Packages file is %q", args.packagesFile)
 	zap.S().Infof("Cleanup interval is %s", cleanInterval.String())
 	zap.S().Infof("Serving web page from %q", args.assetsDirectory)
@@ -112,10 +116,14 @@ func start(goRoot string, args appArgs) error {
 	go store.StartCleaner(ctx, cleanInterval, nil)
 
 	r := mux.NewRouter()
-	pg := goplay.NewClient(args.playgroundUrl, goplay.DefaultUserAgent, 15*time.Second)
-
+	pgClient := goplay.NewClient(args.playgroundURL, goplay.DefaultUserAgent, args.connectTimeout)
+	goTipClient := goplay.NewClient(args.goTipPlaygroundURL, goplay.DefaultUserAgent, args.connectTimeout)
+	clients := &langserver.PlaygroundServices{
+		Default: pgClient,
+		GoTip:   goTipClient,
+	}
 	// API routes
-	langserver.New(Version, pg, packages, compiler.NewBuildService(zap.S(), store)).
+	langserver.New(Version, clients, packages, compiler.NewBuildService(zap.S(), store)).
 		Mount(r.PathPrefix("/api").Subrouter())
 
 	// Web UI routes

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -52,7 +52,7 @@ func main() {
 	flag.StringVar(&args.buildDir, "wasm-build-dir", os.TempDir(), "Directory for WASM builds")
 	flag.StringVar(&args.cleanupInterval, "clean-interval", "10m", "Build directory cleanup interval")
 	flag.StringVar(&args.playgroundURL, "playground-url", goplay.DefaultPlaygroundURL, "Go Playground URL")
-	flag.StringVar(&args.goTipPlaygroundURL, "gotip-playground-url", goplay.DefaultGoTipPlaygroundURL, "GoTip Playground URL")
+	flag.StringVar(&args.goTipPlaygroundURL, "gotip-url", goplay.DefaultGoTipPlaygroundURL, "GoTip Playground URL")
 	flag.BoolVar(&args.debug, "debug", false, "Enable debug mode")
 	flag.StringVar(&args.assetsDirectory, "static-dir", filepath.Join(wd, "public"), "Path to web page assets (HTML, JS, etc)")
 	flag.DurationVar(&args.connectTimeout, "timeout", 15*time.Second, "Go Playground server connect timeout")

--- a/pkg/goplay/client.go
+++ b/pkg/goplay/client.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	DefaultUserAgent     = "goplay.tools/1.0 (http://goplay.tools/)"
-	DefaultPlaygroundURL = "https://play.golang.org"
+	DefaultUserAgent          = "goplay.tools/1.0 (http://goplay.tools/)"
+	DefaultPlaygroundURL      = "https://play.golang.org"
+	DefaultGoTipPlaygroundURL = "https://gotipplay.golang.org"
 
 	// maxSnippetSize value taken from
 	// https://github.com/golang/playground/blob/master/app/goplay/share.go

--- a/pkg/langserver/server.go
+++ b/pkg/langserver/server.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -26,27 +27,33 @@ const (
 	wasmMimeType     = "application/wasm"
 	formatQueryParam = "format"
 	artifactParamVal = "artifactId"
+	goTipQueryParam  = "gotip"
 )
+
+type PlaygroundServices struct {
+	Default *goplay.Client
+	GoTip   *goplay.Client
+}
 
 // Service is language server service
 type Service struct {
-	version    string
-	log        *zap.SugaredLogger
-	index      analyzer.PackageIndex
-	compiler   compiler.BuildService
-	playground *goplay.Client
-	limiter    *rate.Limiter
+	version     string
+	log         *zap.SugaredLogger
+	index       analyzer.PackageIndex
+	compiler    compiler.BuildService
+	playgrounds *PlaygroundServices
+	limiter     *rate.Limiter
 }
 
 // New is Service constructor
-func New(version string, playground *goplay.Client, packages []*analyzer.Package, builder compiler.BuildService) *Service {
+func New(version string, playgrounds *PlaygroundServices, packages []*analyzer.Package, builder compiler.BuildService) *Service {
 	return &Service{
-		compiler:   builder,
-		version:    version,
-		playground: playground,
-		log:        zap.S().Named("langserver"),
-		index:      analyzer.BuildPackageIndex(packages),
-		limiter:    rate.NewLimiter(rate.Every(frameTime), compileRequestsPerFrame),
+		compiler:    builder,
+		version:     version,
+		playgrounds: playgrounds,
+		log:         zap.S().Named("langserver"),
+		index:       analyzer.BuildPackageIndex(packages),
+		limiter:     rate.NewLimiter(rate.Every(frameTime), compileRequestsPerFrame),
 	}
 }
 
@@ -122,7 +129,7 @@ func (s *Service) provideSuggestion(req SuggestionRequest) (*SuggestionsResponse
 }
 
 // HandleGetVersion handles /api/version
-func (s *Service) HandleGetVersion(w http.ResponseWriter, r *http.Request) error {
+func (s *Service) HandleGetVersion(w http.ResponseWriter, _ *http.Request) error {
 	WriteJSON(w, VersionResponse{Version: s.version})
 	return nil
 }
@@ -149,7 +156,7 @@ func (s *Service) HandleFormatCode(w http.ResponseWriter, r *http.Request) error
 		return err
 	}
 
-	formatted, _, err := s.goImportsCode(r.Context(), src)
+	formatted, _, err := s.goImportsCode(r, src)
 	if err != nil {
 		if goplay.IsCompileError(err) {
 			return NewHTTPError(http.StatusBadRequest, err)
@@ -165,7 +172,8 @@ func (s *Service) HandleFormatCode(w http.ResponseWriter, r *http.Request) error
 
 // HandleShare handles snippet share
 func (s *Service) HandleShare(w http.ResponseWriter, r *http.Request) error {
-	shareID, err := s.playground.Share(r.Context(), r.Body)
+	client := s.getPlaygroundClientFromRequest(r)
+	shareID, err := client.Share(r.Context(), r.Body)
 	defer r.Body.Close()
 	if err != nil {
 		if err == goplay.ErrSnippetTooLarge {
@@ -184,7 +192,8 @@ func (s *Service) HandleShare(w http.ResponseWriter, r *http.Request) error {
 func (s *Service) HandleGetSnippet(w http.ResponseWriter, r *http.Request) error {
 	vars := mux.Vars(r)
 	snippetID := vars["id"]
-	snippet, err := s.playground.GetSnippet(r.Context(), snippetID)
+	client := s.getPlaygroundClientFromRequest(r)
+	snippet, err := client.GetSnippet(r.Context(), snippetID)
 	if err != nil {
 		if err == goplay.ErrSnippetNotFound {
 			return Errorf(http.StatusNotFound, "snippet %q not found", snippetID)
@@ -218,7 +227,7 @@ func (s *Service) HandleRunCode(w http.ResponseWriter, r *http.Request) error {
 
 	var changed bool
 	if shouldFormat {
-		src, changed, err = s.goImportsCode(r.Context(), src)
+		src, changed, err = s.goImportsCode(r, src)
 		if err != nil {
 			if goplay.IsCompileError(err) {
 				return NewHTTPError(http.StatusBadRequest, err)
@@ -228,7 +237,8 @@ func (s *Service) HandleRunCode(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	res, err := s.playground.Compile(r.Context(), src)
+	client := s.getPlaygroundClientFromRequest(r)
+	res, err := client.Compile(r.Context(), src)
 	if err != nil {
 		return err
 	}
@@ -276,6 +286,25 @@ func (s *Service) HandleArtifactRequest(w http.ResponseWriter, r *http.Request) 
 	return nil
 }
 
+func (s *Service) getPlaygroundClientFromRequest(r *http.Request) *goplay.Client {
+	goTipParam := strings.TrimSpace(r.URL.Query().Get(goTipQueryParam))
+	if goTipParam == "" {
+		return s.playgrounds.Default
+	}
+
+	goTipEnabled, err := strconv.ParseBool(goTipParam)
+	if err != nil {
+		s.log.Debugw("invalid goTip query parameter value, fallback to default", zap.Error(err), zap.String("value", goTipParam))
+		return s.playgrounds.Default
+	}
+
+	if goTipEnabled {
+		return s.playgrounds.GoTip
+	}
+
+	return s.playgrounds.Default
+}
+
 // HandleCompile handles WASM build request
 func (s *Service) HandleCompile(w http.ResponseWriter, r *http.Request) error {
 	// Limit for request timeout
@@ -299,7 +328,7 @@ func (s *Service) HandleCompile(w http.ResponseWriter, r *http.Request) error {
 
 	var changed bool
 	if shouldFormat {
-		src, changed, err = s.goImportsCode(r.Context(), src)
+		src, changed, err = s.goImportsCode(r, src)
 		if err != nil {
 			if goplay.IsCompileError(err) {
 				return NewHTTPError(http.StatusBadRequest, err)
@@ -333,8 +362,9 @@ func (s *Service) HandleCompile(w http.ResponseWriter, r *http.Request) error {
 // if any error occurs, it sends error response to client and closes connection
 //
 // if "format" url query param is undefined or set to "false", just returns code as is
-func (s *Service) goImportsCode(ctx context.Context, src []byte) ([]byte, bool, error) {
-	resp, err := s.playground.GoImports(ctx, src)
+func (s *Service) goImportsCode(r *http.Request, src []byte) ([]byte, bool, error) {
+	client := s.getPlaygroundClientFromRequest(r)
+	resp, err := client.GoImports(r.Context(), src)
 	if err != nil {
 		if err == goplay.ErrSnippetTooLarge {
 			return nil, false, NewHTTPError(http.StatusRequestEntityTooLarge, err)

--- a/pkg/langserver/server.go
+++ b/pkg/langserver/server.go
@@ -24,10 +24,11 @@ const (
 	frameTime               = time.Second
 	maxBuildTimeDuration    = time.Second * 30
 
-	wasmMimeType     = "application/wasm"
-	formatQueryParam = "format"
-	artifactParamVal = "artifactId"
-	goTipQueryParam  = "gotip"
+	wasmMimeType           = "application/wasm"
+	formatQueryParam       = "format"
+	artifactParamVal       = "artifactId"
+	playgroundBackendParam = "backend"
+	playgroundGoTip        = "gotip"
 )
 
 type PlaygroundServices struct {
@@ -287,18 +288,8 @@ func (s *Service) HandleArtifactRequest(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Service) getPlaygroundClientFromRequest(r *http.Request) *goplay.Client {
-	goTipParam := strings.TrimSpace(r.URL.Query().Get(goTipQueryParam))
-	if goTipParam == "" {
-		return s.playgrounds.Default
-	}
-
-	goTipEnabled, err := strconv.ParseBool(goTipParam)
-	if err != nil {
-		s.log.Debugw("invalid goTip query parameter value, fallback to default", zap.Error(err), zap.String("value", goTipParam))
-		return s.playgrounds.Default
-	}
-
-	if goTipEnabled {
+	playgroundBackend := strings.TrimSpace(r.URL.Query().Get(playgroundBackendParam))
+	if playgroundBackend == playgroundGoTip {
 		s.log.Debugw("Using goTip backend for request", zap.String("url", r.RequestURI))
 		return s.playgrounds.GoTip
 	}

--- a/pkg/langserver/server.go
+++ b/pkg/langserver/server.go
@@ -299,6 +299,7 @@ func (s *Service) getPlaygroundClientFromRequest(r *http.Request) *goplay.Client
 	}
 
 	if goTipEnabled {
+		s.log.Debugw("Using goTip backend for request", zap.String("url", r.RequestURI))
 		return s.playgrounds.GoTip
 	}
 

--- a/web/src/components/settings/SettingsModal.tsx
+++ b/web/src/components/settings/SettingsModal.tsx
@@ -1,19 +1,33 @@
 import React from 'react';
-import { Checkbox, Dropdown, getTheme, IconButton, IDropdownOption, Modal } from '@fluentui/react';
-import { Pivot, PivotItem } from '@fluentui/react/lib/Pivot';
-import { MessageBar, MessageBarType } from '@fluentui/react/lib/MessageBar';
-import { Link } from '@fluentui/react/lib/Link';
+import {
+  Checkbox,
+  Dropdown,
+  getTheme,
+  IconButton,
+  IDropdownOption,
+  Modal
+} from '@fluentui/react';
+import {Pivot, PivotItem} from '@fluentui/react/lib/Pivot';
+import {MessageBar, MessageBarType} from '@fluentui/react/lib/MessageBar';
+import {Link} from '@fluentui/react/lib/Link';
 
-import { getContentStyles, getIconButtonStyles } from '~/styles/modal';
+import {getContentStyles, getIconButtonStyles} from '~/styles/modal';
 import SettingsProperty from './SettingsProperty';
-import { MonacoSettings, RuntimeType } from '~/services/config';
-import { DEFAULT_FONT, getAvailableFonts } from '~/services/fonts';
-import { BuildParamsArgs, Connect, MonacoParamsChanges, SettingsState } from '~/store';
+import {MonacoSettings, RuntimeType} from '~/services/config';
+import {DEFAULT_FONT, getAvailableFonts} from '~/services/fonts';
+import {
+  BuildParamsArgs,
+  Connect,
+  MonacoParamsChanges,
+  SettingsState
+} from '~/store';
 
 const WASM_SUPPORTED = 'WebAssembly' in window;
 
 const COMPILER_OPTIONS: IDropdownOption[] = [
   { key: RuntimeType.GoPlayground, text: 'Go Playground' },
+  {
+    key: RuntimeType.GoTipPlayground, text: 'Go Playground (Go Tip)' },
   {
     key: RuntimeType.WebAssembly,
     text: `WebAssembly (${WASM_SUPPORTED ? 'Experimental' : 'Unsupported'})`,
@@ -62,6 +76,7 @@ export interface SettingsProps {
 interface SettingsModalState {
   isOpen?: boolean,
   showWarning?: boolean
+  showGoTipMessage?: boolean
 }
 
 @Connect(state => ({
@@ -77,7 +92,8 @@ export default class SettingsModal extends React.Component<SettingsProps, Settin
     super(props);
     this.state = {
       isOpen: props.isOpen,
-      showWarning: props.settings.runtime === RuntimeType.WebAssembly
+      showWarning: props.settings.runtime === RuntimeType.WebAssembly,
+      showGoTipMessage: props.settings.runtime === RuntimeType.GoTipPlayground,
     }
   }
 
@@ -94,14 +110,11 @@ export default class SettingsModal extends React.Component<SettingsProps, Settin
     this.changes.monaco[key] = val;
   }
 
-  get wasmWarningVisibility() {
-    return this.state.showWarning ? 'visible' : 'hidden'
-  }
-
   render() {
     const theme = getTheme();
     const contentStyles = getContentStyles(theme);
     const iconButtonStyles = getIconButtonStyles(theme);
+    const { showGoTipMessage, showWarning } = this.state;
     return (
       <Modal
         titleAriaId={this.titleID}
@@ -242,19 +255,32 @@ export default class SettingsModal extends React.Component<SettingsProps, Settin
                       autoFormat: this.props.settings?.autoFormat ?? true,
                     };
 
-                    this.setState({ showWarning: val?.key === RuntimeType.WebAssembly });
+                    this.setState({
+                      showWarning: val?.key === RuntimeType.WebAssembly,
+                      showGoTipMessage: val?.key === RuntimeType.GoTipPlayground
+                    });
                   }}
                 />}
               />
-              <div style={{ visibility: this.wasmWarningVisibility, marginTop: '10px' }}>
-                <MessageBar isMultiline={true} messageBarType={MessageBarType.warning}>
-                  <b>WebAssembly</b> is a modern runtime that gives you additional features
-                  like possibility to interact with web browser but is unstable.
-                  Use it at your own risk.
-                  <p>
-                    See<Link href='https://github.com/golang/go/wiki/WebAssembly' target='_blank'>documentation</Link> for more details.
-                  </p>
-                </MessageBar>
+              <div style={{ marginTop: '10px' }}>
+                { showWarning && (
+                  <MessageBar isMultiline={true} messageBarType={MessageBarType.warning}>
+                    <b>WebAssembly</b> is a modern runtime that gives you additional features
+                    like possibility to interact with web browser but is unstable.
+                    Use it at your own risk.
+                    <p>
+                      See<Link href='https://github.com/golang/go/wiki/WebAssembly' target='_blank'>documentation</Link> for more details.
+                    </p>
+                  </MessageBar>
+                )}
+                { showGoTipMessage && (
+                  <MessageBar isMultiline={true} messageBarType={MessageBarType.warning}>
+                    <b>Gotip Playground</b> uses the current unstable development build of Go.
+                    <p>
+                      See<Link href='https://pkg.go.dev/golang.org/dl/gotip' target='_blank'>gotip help</Link> for more details.
+                    </p>
+                  </MessageBar>
+                )}
               </div>
               <SettingsProperty
                 key='autoFormat'

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -6,6 +6,11 @@ import config from './config';
 const apiAddress = `${config.serverUrl}/api`;
 const axiosClient = axios.default.create({ baseURL: apiAddress });
 
+export enum PlaygroundBackend {
+  Default = '',
+  GoTip = 'gotip'
+}
+
 export enum EvalEventKind {
   Stdout = 'stdout',
   Stderr = 'stderr'
@@ -100,12 +105,12 @@ class Client implements IAPIClient {
     return resp;
   }
 
-  async evaluateCode(code: string, format: boolean, goTip = false): Promise<RunResponse> {
-    return this.post<RunResponse>(`/run?format=${Boolean(format)}&gotip=${Boolean(goTip)}`, code);
+  async evaluateCode(code: string, format: boolean, backend = PlaygroundBackend.Default): Promise<RunResponse> {
+    return this.post<RunResponse>(`/run?format=${Boolean(format)}&backend=${backend}`, code);
   }
 
-  async formatCode(code: string, goTip=false): Promise<RunResponse> {
-    return this.post<RunResponse>(`/format?gotip=${Boolean(goTip)}`, code);
+  async formatCode(code: string, backend = PlaygroundBackend.Default): Promise<RunResponse> {
+    return this.post<RunResponse>(`/format?backend=${backend}`, code);
   }
 
   async getSnippet(id: string): Promise<Snippet> {

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -104,8 +104,8 @@ class Client implements IAPIClient {
     return this.post<RunResponse>(`/run?format=${Boolean(format)}&gotip=${Boolean(goTip)}`, code);
   }
 
-  async formatCode(code: string): Promise<RunResponse> {
-    return this.post<RunResponse>('/format', code);
+  async formatCode(code: string, goTip=false): Promise<RunResponse> {
+    return this.post<RunResponse>(`/format?gotip=${Boolean(goTip)}`, code);
   }
 
   async getSnippet(id: string): Promise<Snippet> {

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -100,8 +100,8 @@ class Client implements IAPIClient {
     return resp;
   }
 
-  async evaluateCode(code: string, format: boolean): Promise<RunResponse> {
-    return this.post<RunResponse>(`/run?format=${Boolean(format)}`, code);
+  async evaluateCode(code: string, format: boolean, goTip = false): Promise<RunResponse> {
+    return this.post<RunResponse>(`/run?format=${Boolean(format)}&gotip=${Boolean(goTip)}`, code);
   }
 
   async formatCode(code: string): Promise<RunResponse> {

--- a/web/src/services/config.ts
+++ b/web/src/services/config.ts
@@ -9,8 +9,9 @@ const MONACO_SETTINGS = 'ms.monaco.settings';
 
 
 export enum RuntimeType {
-  GoPlayground = 'GO_PLAYGROUND',
-  WebAssembly = 'WASM'
+  GoPlayground    = 'GO_PLAYGROUND',
+  GoTipPlayground = 'GO_TIP_PLAYGROUND',
+  WebAssembly     = 'WASM'
 }
 
 export interface MonacoSettings {

--- a/web/src/store/dispatch.ts
+++ b/web/src/store/dispatch.ts
@@ -1,21 +1,24 @@
-import { saveAs } from 'file-saver';
-import { push } from 'connected-react-router';
+import {saveAs} from 'file-saver';
+import {push} from 'connected-react-router';
 import {
   Action,
-  ActionType, MonacoParamsChanges, newBuildParamsChangeAction,
+  ActionType,
+  MonacoParamsChanges,
+  newBuildParamsChangeAction,
   newBuildResultAction,
   newErrorAction,
   newImportFileAction,
-  newLoadingAction, newMonacoParamsChangeAction,
+  newLoadingAction,
+  newMonacoParamsChangeAction,
   newProgramWriteAction,
   newToggleThemeAction,
   newUIStateChangeAction
 } from './actions';
-import client, { EvalEventKind, instantiateStreaming } from '~/services/api';
-import config, { RuntimeType } from '~/services/config';
-import { DEMO_CODE } from '~/components/editor/props';
-import { getImportObject, goRun } from '~/services/go';
-import { State } from './state';
+import client, {EvalEventKind, instantiateStreaming} from '~/services/api';
+import config, {RuntimeType} from '~/services/config';
+import {DEMO_CODE} from '~/components/editor/props';
+import {getImportObject, goRun} from '~/services/go';
+import {State} from './state';
 
 export type StateProvider = () => State
 export type DispatchFn = (a: Action | any) => any
@@ -147,8 +150,11 @@ export const formatFileDispatcher: Dispatcher =
   async (dispatch: DispatchFn, getState: StateProvider) => {
     dispatch(newLoadingAction());
     try {
-      const { code } = getState().editor;
-      const res = await client.formatCode(code);
+      // Format code using GoTip is enabled to support
+      // any syntax changes from unstable Go specs.
+      const { editor: {code}, settings: { runtime } } = getState();
+      const isGoTip = runtime === RuntimeType.GoTipPlayground;
+      const res = await client.formatCode(code, isGoTip);
 
       if (res.formatted) {
         dispatch(newBuildResultAction(res));

--- a/web/src/store/dispatch.ts
+++ b/web/src/store/dispatch.ts
@@ -120,6 +120,10 @@ export const runFileDispatcher: Dispatcher =
           const res = await client.evaluateCode(editor.code, settings.autoFormat);
           dispatch(newBuildResultAction(res));
           break;
+        case RuntimeType.GoTipPlayground:
+          const rsp = await client.evaluateCode(editor.code, settings.autoFormat, true);
+          dispatch(newBuildResultAction(rsp));
+          break;
         case RuntimeType.WebAssembly:
           let resp = await client.build(editor.code, settings.autoFormat);
           let wasmFile = await client.getArtifact(resp.fileName);

--- a/web/src/store/dispatch.ts
+++ b/web/src/store/dispatch.ts
@@ -14,7 +14,11 @@ import {
   newToggleThemeAction,
   newUIStateChangeAction
 } from './actions';
-import client, {EvalEventKind, instantiateStreaming} from '~/services/api';
+import client, {
+  EvalEventKind,
+  instantiateStreaming,
+  PlaygroundBackend
+} from '~/services/api';
 import config, {RuntimeType} from '~/services/config';
 import {DEMO_CODE} from '~/components/editor/props';
 import {getImportObject, goRun} from '~/services/go';
@@ -124,7 +128,7 @@ export const runFileDispatcher: Dispatcher =
           dispatch(newBuildResultAction(res));
           break;
         case RuntimeType.GoTipPlayground:
-          const rsp = await client.evaluateCode(editor.code, settings.autoFormat, true);
+          const rsp = await client.evaluateCode(editor.code, settings.autoFormat, PlaygroundBackend.GoTip);
           dispatch(newBuildResultAction(rsp));
           break;
         case RuntimeType.WebAssembly:
@@ -153,8 +157,8 @@ export const formatFileDispatcher: Dispatcher =
       // Format code using GoTip is enabled to support
       // any syntax changes from unstable Go specs.
       const { editor: {code}, settings: { runtime } } = getState();
-      const isGoTip = runtime === RuntimeType.GoTipPlayground;
-      const res = await client.formatCode(code, isGoTip);
+      const backend = runtime === RuntimeType.GoTipPlayground ? PlaygroundBackend.GoTip : PlaygroundBackend.Default;
+      const res = await client.formatCode(code, backend);
 
       if (res.formatted) {
         dispatch(newBuildResultAction(res));


### PR DESCRIPTION
Add support of [gotipplay.golang.org](https://gotipplay.golang.org/) backend for running code using experimental Go versions.

<img width="498" alt="image" src="https://user-images.githubusercontent.com/9203548/157974769-8a689463-bb39-466a-9a9f-d99ddbe2b109.png">

GoTip playground URL can be configured using `-gotip-url` flag or using `APP_GOTIP_URL` environment URL (Docker image only)