### PR TITLE
WebAssembly: fix execution context for methods that require Window interface 

### DIFF
--- a/web/src/services/go/snippets.json
+++ b/web/src/services/go/snippets.json
@@ -131,6 +131,11 @@
       "label": "Display image",
       "snippet": "XN6x3L23Vok",
       "icon": "FileImage"
+    },
+    {
+      "label": "WebAssembly",
+      "snippet": "NCdgXZrYSk4",
+      "icon": "JS"
     }
   ],
   "Other examples": [


### PR DESCRIPTION
Our playground uses special proxy object to inject/customize global scope of Go's WebAssembly bridge (`wasm_exec.js`) by wrapping `globalThis` with proxy object.

Some `window` calls, like `window.alert` require that execution context object should be `window`.

When proxy object passed instead, occurs an error: 

```
TypeError: 'alert' called on an object that does not implement interface Window
```

Prototype swap by using `setPrototypeOf` also doesn't work.

This PR adds method owner check during method call as a workaround, which replaces proxy object with original `window` during call on any `window` member method (like `alert()`).
