### PR TITLE
Add page preloader and noscript message

### DIFF
--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -136,10 +136,12 @@ func start(goRoot string, args appArgs) error {
 	tplVars := langserver.TemplateArguments{
 		GoogleTagID: args.googleAnalyticsID,
 	}
-	if err := webutil.ValidateGTag(tplVars.GoogleTagID); err != nil {
-		zap.L().Error("invalid GTag ID value, parameter will be ignored",
-			zap.String("gtag", tplVars.GoogleTagID), zap.Error(err))
-		tplVars.GoogleTagID = ""
+	if tplVars.GoogleTagID != "" {
+		if err := webutil.ValidateGTag(tplVars.GoogleTagID); err != nil {
+			zap.L().Error("invalid GTag ID value, parameter will be ignored",
+				zap.String("gtag", tplVars.GoogleTagID), zap.Error(err))
+			tplVars.GoogleTagID = ""
+		}
 	}
 
 	indexHandler := langserver.NewTemplateFileServer(zap.L(), filepath.Join(args.assetsDirectory, langserver.IndexFileName), tplVars)

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -11,11 +11,118 @@
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <title>Better Go Playground</title>
+  <style>
+    .app-preloader {
+        display: block;
+        position: absolute;
+        inset: 0;
+        background: #1f1f1f;
+        color: #f4f4f4;
+        font: 11pt system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
+    }
+
+    .app-preloader__container {
+        height: 100%;
+        width: 100%;
+        max-height: 480px;
+        max-width: 320px;
+        position: absolute;
+        inset: 50%;
+        transform: translate(-50%, -50%);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .app-preloader__content {
+        margin-top: 32px;
+    }
+
+    .app-preloader__content p {
+        margin: 2rem;
+        text-align: center;
+    }
+
+    @keyframes progress-bar-animation {
+        0% {
+            left: -2%;
+            width: 5%;
+        }
+
+        35% {
+            width: 25%;
+        }
+
+        85% {
+            width: 5%;
+        }
+
+        100% {
+            left: 100%;
+            width: 5%;
+        }
+    }
+
+    .app-preloader-progress {
+        background: #333;
+        height: 4px;
+        position: relative;
+        overflow: hidden;
+    }
+
+    .app-preloader-progress__bar {
+        position: absolute;
+        top: 0;
+        left: 0;
+        transition: all 0.2s ease-out 0s;
+        background: dodgerblue;
+        height: 100%;
+    }
+
+    .app-preloader-progress__bar--indeterminate {
+        width: 32%;
+        transition: all 0.5s ease-out 0s;
+        animation: progress-bar-animation 2.3s infinite;
+    }
+
+    @media (prefers-color-scheme: light) {
+        .app-preloader {
+            background: #fff;
+            color: #323130;
+        }
+        .app-preloader-progress {
+            background: #ccc;
+        }
+    }
+  </style>
 </head>
 
 <body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root"></div>
+  <div id="root">
+    <div class="app-preloader">
+      <div class="app-preloader__container">
+        <div><img src="/go-logo-blue.svg" alt="Go Logo" /></div>
+        <div class="app-preloader__content">
+          <noscript>
+            <p>You need to enable JavaScript to run this app.</p>
+            <style>
+              .app-preloader__label {
+                  display: none;
+              }
+              .app-preloader-progress {
+                  display: none
+              }
+            </style>
+          </noscript>
+          <p class="app-preloader__label">Loading playground...</p>
+          <div class="app-preloader-progress">
+            <div class="app-preloader-progress__bar app-preloader-progress__bar--indeterminate"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
   <% if (process.env.NODE_ENV === 'production') { %>
   {{ if .GoogleTagID }}
   <script async src="https://www.googletagmanager.com/gtag/js?id={{.GoogleTagID}}"></script>


### PR DESCRIPTION
Add fancy preloader (for slow internet) and `<noscript>` message if JavaScript is disabled.

<img width="505" alt="image" src="https://user-images.githubusercontent.com/9203548/158096438-b52d1d55-f787-45fb-aeb5-33808d735e3c.png">

<img width="481" alt="image" src="https://user-images.githubusercontent.com/9203548/158096475-cdb3839e-3aac-46c1-b510-299530ba837b.png">
