### PR TITLE
Disable parallel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - name: Set up QEMU
-        if: ${{ matrix.platform != 'linux/amd64' }}
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         if: ${{ matrix.platform != 'linux/amd64' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [ linux/amd64, linux/arm64 ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v2
@@ -55,15 +52,14 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
-        if: ${{ matrix.platform != 'linux/amd64' }}
-        uses: docker/setup-buildx-action@v1
         id: buildx
-      - name: Build and push image (${{ matrix.platform }})
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push image
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./build/Dockerfile
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
Disable parallel build because it breaks image push process by overwriting `amd64` variant with `arm64`.
