### PR TITLE
Hide logo on small screens

### DIFF
--- a/web/src/components/core/Header.css
+++ b/web/src/components/core/Header.css
@@ -36,8 +36,12 @@
 }
 
 @media only screen and (max-width: 600px) {
+  .header__commandBar .ms-CommandBar {
+    padding: 0 10px;
+  }
   .header__logo {
     height: 1em;
-    margin-left: 0;
+    margin: 0 10px;
+    display: none;
   }
 }


### PR DESCRIPTION
Currently, on small mobile screens Go logo is displayed not properly and takes a big piece of screen space hiding **Run** button which is very frequently used.

This PR adds logo hide behavior on small screens adding space for *Run* button.

**Before**

<img width="378" alt="image" src="https://user-images.githubusercontent.com/9203548/160310382-03be4e15-ed68-498d-8ac1-30f2390d7d7e.png">


**After**

<img width="380" alt="image" src="https://user-images.githubusercontent.com/9203548/160310408-ba9cace6-f450-496c-9dc3-c77f5d177ff8.png">
