### PR TITLE
Vertical panel support

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "re-resizable": "^6.9.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-icons": "^4.3.1",
     "react-monaco-editor": "^0.47.0",
     "react-redux": "^7.2.6",
     "react-router-dom": "^5.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "@types/react-dom": "^17.0.11",
     "axios": "^0.25.0",
     "circular-dependency-plugin": "^5.2.2",
+    "clsx": "^1.1.1",
     "connected-react-router": "^6.9.2",
     "copy-to-clipboard": "^3.3.1",
     "craco-alias": "^3.0.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
 import { Switch, Route } from "react-router-dom";
-import { ThemeProvider } from '@fluentui/react';
 
 import { configureStore, createGoConsoleAdapter } from './store';
-import { history } from './store/configure';
-import { bootstrapGo } from './services/go';
-import Playground from '~/components/pages/Playground';
+import { history } from '~/store/configure';
+import { bootstrapGo } from '~/services/go';
 import config from './services/config';
+import Playground from '~/components/pages/Playground';
+import NotFoundPage from "~/components/pages/NotFoundPage";
+import ConnectedThemeProvider from '~/components/utils/ConnectedThemeProvider';
 import './App.css';
-import NotFoundPage from "@components/pages/NotFoundPage";
 
 // Configure store and import config from localStorage
 const store = configureStore();
@@ -19,11 +19,11 @@ config.sync();
 // Bootstrap Go and storage bridge
 bootstrapGo(createGoConsoleAdapter(a => store.dispatch(a)));
 
-function App() {
+const App = () => {
   return (
     <Provider store={store}>
       <ConnectedRouter history={history}>
-        <ThemeProvider className="App">
+        <ConnectedThemeProvider className="App">
           <Switch>
             <Route
               path={[
@@ -32,10 +32,10 @@ function App() {
               ]}
               exact
               component={Playground}
-            ></Route>
+            />
             <Route path="*" component={NotFoundPage}/>
           </Switch>
-        </ThemeProvider>
+        </ConnectedThemeProvider>
       </ConnectedRouter>
     </Provider>
   );

--- a/web/src/components/core/Layout/Layout.css
+++ b/web/src/components/core/Layout/Layout.css
@@ -1,0 +1,13 @@
+.Layout {
+  display: flex;
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.Layout.Layout--vertical {
+  flex-direction: column;
+}
+
+.Layout.Layout--horizontal {
+  flex-direction: row;
+}

--- a/web/src/components/core/Layout/Layout.tsx
+++ b/web/src/components/core/Layout/Layout.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {LayoutType} from '~/styles/layout';
+import './Layout.css';
+
+interface Props {
+  layout?: LayoutType;
+}
+
+const Layout: React.FC<Props> = ({layout = LayoutType.Vertical, children}) => (
+  <div className={`Layout Layout--${layout}`}>
+    {children}
+  </div>
+);
+
+export default Layout;

--- a/web/src/components/core/Layout/index.ts
+++ b/web/src/components/core/Layout/index.ts
@@ -1,0 +1,1 @@
+export * from './Layout';

--- a/web/src/components/core/Panel/PanelAction.css
+++ b/web/src/components/core/Panel/PanelAction.css
@@ -14,3 +14,10 @@
 .PanelAction:hover {
   background: var(--pg-panel-action-hover-bg);
 }
+
+@media (max-width: 480px) {
+  .PanelAction--desktopOnly {
+    display: none;
+  }
+}
+

--- a/web/src/components/core/Panel/PanelAction.css
+++ b/web/src/components/core/Panel/PanelAction.css
@@ -1,0 +1,16 @@
+.PanelAction {
+  background: none;
+  font: inherit;
+  color: inherit;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  padding: 3px;
+  border-radius: 5px;
+  margin-right: 4px;
+}
+
+.PanelAction:hover {
+  background: var(--pg-panel-action-hover-bg);
+}

--- a/web/src/components/core/Panel/PanelAction.tsx
+++ b/web/src/components/core/Panel/PanelAction.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import './PanelAction.css';
+import {getTheme} from "@fluentui/react";
+
+export interface PanelActionProps {
+  hidden?: boolean
+  icon: React.ReactNode
+  label: string
+  onClick?: () => void
+}
+
+const PanelAction: React.FC<PanelActionProps> = ({hidden, icon, label, onClick}) => {
+  const {
+    palette: { neutralQuaternaryAlt }
+  } = getTheme();
+  if (hidden) {
+    return null;
+  }
+
+  return (
+    <button
+      className="PanelAction"
+      title={label}
+      onClick={onClick}
+    >
+      {icon}
+    </button>
+  );
+};
+
+export default PanelAction;

--- a/web/src/components/core/Panel/PanelAction.tsx
+++ b/web/src/components/core/Panel/PanelAction.tsx
@@ -1,21 +1,23 @@
 import React from 'react';
+import clsx from 'clsx';
 import './PanelAction.css';
 
 export interface PanelActionProps {
   hidden?: boolean
   icon: React.ReactNode
   label: string
+  desktopOnly?: boolean
   onClick?: () => void
 }
 
-const PanelAction: React.FC<PanelActionProps> = ({hidden, icon, label, onClick}) => {
+const PanelAction: React.FC<PanelActionProps> = ({hidden, icon, desktopOnly, label, onClick}) => {
   if (hidden) {
     return null;
   }
 
   return (
     <button
-      className="PanelAction"
+      className={clsx('PanelAction', desktopOnly && 'PanelAction--desktopOnly')}
       title={label}
       onClick={onClick}
     >

--- a/web/src/components/core/Panel/PanelAction.tsx
+++ b/web/src/components/core/Panel/PanelAction.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import './PanelAction.css';
-import {getTheme} from "@fluentui/react";
 
 export interface PanelActionProps {
   hidden?: boolean
@@ -10,9 +9,6 @@ export interface PanelActionProps {
 }
 
 const PanelAction: React.FC<PanelActionProps> = ({hidden, icon, label, onClick}) => {
-  const {
-    palette: { neutralQuaternaryAlt }
-  } = getTheme();
   if (hidden) {
     return null;
   }

--- a/web/src/components/core/Panel/PanelHeader.css
+++ b/web/src/components/core/Panel/PanelHeader.css
@@ -1,0 +1,34 @@
+.PanelHeader {
+  padding: 8px 8px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  /*justify-content: center;*/
+  justify-content: space-between;
+}
+
+.PanelHeader__title {
+  text-transform: uppercase;
+  font-size: 11px;
+  padding: 0 7px;
+}
+
+.PanelHeader__side--left {
+  display: flex;
+  align-items: center;
+  /*background: #ff00aacc;*/
+}
+
+.PanelHeader__commands {
+  display: flex;
+  flex-direction: row;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  /*background: #00ffaacc;*/
+}
+
+.PanelHeader__commands>li {
+  margin: 0;
+  padding: 0;
+}

--- a/web/src/components/core/Panel/PanelHeader.css
+++ b/web/src/components/core/Panel/PanelHeader.css
@@ -5,6 +5,8 @@
   align-items: center;
   /*justify-content: center;*/
   justify-content: space-between;
+  background-color: var(--pg-panel-action-background);
+  color: var(--pg-panel-action-color);
 }
 
 .PanelHeader__title {

--- a/web/src/components/core/Panel/PanelHeader.tsx
+++ b/web/src/components/core/Panel/PanelHeader.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { getTheme } from '@fluentui/react';
+import React, {useContext} from 'react';
+import {ITheme, ThemeContext} from '@fluentui/react';
 import PanelAction, {PanelActionProps} from '@components/core/Panel/PanelAction';
 import './PanelHeader.css';
 
@@ -9,9 +9,10 @@ interface Props {
 }
 
 const PanelHeader: React.FC<Props> = ({label, commands}) => {
+  const theme = useContext(ThemeContext);
   const {
     palette: { neutralLight, neutralDark, neutralQuaternaryAlt }
-  } = getTheme();
+  } = theme as ITheme;
 
   return (
     <div

--- a/web/src/components/core/Panel/PanelHeader.tsx
+++ b/web/src/components/core/Panel/PanelHeader.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { getTheme } from '@fluentui/react';
+import PanelAction from '@components/core/Panel/PanelAction';
+import './PanelHeader.css';
+
+interface Props {
+  label: string
+  commands?: {[key: string]: {hidden?: boolean, icon: React.ReactNode, label: string}}
+}
+
+const PanelHeader: React.FC<Props> = ({label, commands}) => {
+  const {
+    palette: { neutralLight, neutralDark, neutralQuaternaryAlt }
+  } = getTheme();
+
+  return (
+    <div
+      className="PanelHeader"
+      style={{
+        backgroundColor: neutralLight,
+        color: neutralDark,
+        '--pg-panel-action-hover-bg': neutralQuaternaryAlt
+      } as any}
+    >
+      <div className="PanelHeader__side--left">
+        <span className="PanelHeader__title">
+          {label}
+        </span>
+      </div>
+      <ul className="PanelHeader__commands">
+        {commands ? (
+          Object.entries(commands)
+            .map(([key, props]) => ({key, ...props}))
+            .filter(({hidden}) => !hidden)
+            .map((props) => (
+              <li key={props.key}>
+                <PanelAction {...props} />
+              </li>
+            ))
+        ) : null}
+      </ul>
+    </div>
+  );
+};
+
+export default PanelHeader;

--- a/web/src/components/core/Panel/PanelHeader.tsx
+++ b/web/src/components/core/Panel/PanelHeader.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { getTheme } from '@fluentui/react';
-import PanelAction from '@components/core/Panel/PanelAction';
+import PanelAction, {PanelActionProps} from '@components/core/Panel/PanelAction';
 import './PanelHeader.css';
 
 interface Props {
   label: string
-  commands?: {[key: string]: {hidden?: boolean, icon: React.ReactNode, label: string}}
+  commands?: {[key: string]: PanelActionProps},
 }
 
 const PanelHeader: React.FC<Props> = ({label, commands}) => {
@@ -32,8 +32,8 @@ const PanelHeader: React.FC<Props> = ({label, commands}) => {
           Object.entries(commands)
             .map(([key, props]) => ({key, ...props}))
             .filter(({hidden}) => !hidden)
-            .map((props) => (
-              <li key={props.key}>
+            .map(({key, ...props}) => (
+              <li key={key}>
                 <PanelAction {...props} />
               </li>
             ))

--- a/web/src/components/modals/ChangeLogModal.tsx
+++ b/web/src/components/modals/ChangeLogModal.tsx
@@ -41,7 +41,7 @@ export default function ChangeLogModal(props: ChangeLogModalProps) {
       </div>
       <div id={SUB_TITLE_ID} className={contentStyles.body}>
         {Object.entries(changelog).map(([section, items]) => (
-          <>
+          <div key={section}>
             <b>{section}</b>
             <ul>
               {items.map(({issueId, url, description}) => (
@@ -57,7 +57,7 @@ export default function ChangeLogModal(props: ChangeLogModalProps) {
                 </li>
               ))}
             </ul>
-          </>
+          </div>
         ))}
         <p>
           And more!

--- a/web/src/components/pages/Playground.css
+++ b/web/src/components/pages/Playground.css
@@ -1,10 +1,11 @@
-.playground {
+.Playground {
   position: absolute;
   top: 0;
   left: 0;
   bottom: 0;
   right: 0;
+  height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
-  /*background: #ccc;*/
 }

--- a/web/src/components/pages/Playground.tsx
+++ b/web/src/components/pages/Playground.tsx
@@ -2,29 +2,36 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { connect } from 'react-redux';
 
-import { newSnippetLoadDispatcher } from "~/store";
+import { dispatchPanelLayoutChange, newSnippetLoadDispatcher} from '~/store';
 import { Header } from '~/components/core/Header';
 import CodeEditor from '~/components/editor/CodeEditor';
 import FlexContainer from '~/components/editor/FlexContainer';
 import ResizablePreview from '~/components/preview/ResizablePreview';
 import Layout from '~/components/core/Layout/Layout';
 import StatusBar from '~/components/core/StatusBar';
-import { LayoutType} from '~/styles/layout';
 
 import './Playground.css';
 
-const Playground = connect()((props: any) => {
+const CodeContainer = connect()(({dispatch}: any) => {
   const { snippetID } = useParams();
-  props.dispatch(newSnippetLoadDispatcher(snippetID));
+  dispatch(newSnippetLoadDispatcher(snippetID));
+  return (
+    <CodeEditor />
+  );
+})
 
+const Playground = connect(({panel}: any) => ({panelProps: panel}))(({panelProps, dispatch}: any) => {
   return (
     <div className="Playground">
       <Header />
-      <Layout layout={LayoutType.Vertical}>
+      <Layout layout={panelProps.layout}>
         <FlexContainer>
-          <CodeEditor />
+          <CodeContainer />
         </FlexContainer>
-        <ResizablePreview layout={LayoutType.Vertical} collapsed={false} />
+        <ResizablePreview
+          {...panelProps}
+          onViewChange={changes => dispatch(dispatchPanelLayoutChange(changes))}
+        />
       </Layout>
       <StatusBar />
     </div>

--- a/web/src/components/pages/Playground.tsx
+++ b/web/src/components/pages/Playground.tsx
@@ -9,6 +9,7 @@ import FlexContainer from '~/components/editor/FlexContainer';
 import ResizablePreview from '~/components/preview/ResizablePreview';
 import Layout from '~/components/core/Layout/Layout';
 import StatusBar from '~/components/core/StatusBar';
+import {LayoutType} from "~/styles/layout";
 
 import './Playground.css';
 
@@ -18,11 +19,11 @@ const Playground = connect()((props: any) => {
 
   return <div className="Playground">
     <Header />
-    <Layout>
+    <Layout layout={LayoutType.Vertical}>
       <FlexContainer>
         <CodeEditor />
       </FlexContainer>
-      <ResizablePreview />
+      <ResizablePreview layout={LayoutType.Vertical} collapsed={false} />
     </Layout>
     <StatusBar />
   </div>;

--- a/web/src/components/pages/Playground.tsx
+++ b/web/src/components/pages/Playground.tsx
@@ -7,6 +7,7 @@ import { Header } from '~/components/core/Header';
 import CodeEditor from '~/components/editor/CodeEditor';
 import FlexContainer from '~/components/editor/FlexContainer';
 import ResizablePreview from '~/components/preview/ResizablePreview';
+import Layout from '~/components/core/Layout/Layout';
 import StatusBar from '~/components/core/StatusBar';
 
 import './Playground.css';
@@ -15,12 +16,14 @@ const Playground = connect()((props: any) => {
   const { snippetID } = useParams();
   props.dispatch(newSnippetLoadDispatcher(snippetID));
 
-  return <div className="playground">
+  return <div className="Playground">
     <Header />
-    <FlexContainer>
-      <CodeEditor />
-    </FlexContainer>
-    <ResizablePreview />
+    <Layout>
+      <FlexContainer>
+        <CodeEditor />
+      </FlexContainer>
+      <ResizablePreview />
+    </Layout>
     <StatusBar />
   </div>;
 });

--- a/web/src/components/pages/Playground.tsx
+++ b/web/src/components/pages/Playground.tsx
@@ -9,7 +9,7 @@ import FlexContainer from '~/components/editor/FlexContainer';
 import ResizablePreview from '~/components/preview/ResizablePreview';
 import Layout from '~/components/core/Layout/Layout';
 import StatusBar from '~/components/core/StatusBar';
-import {LayoutType} from "~/styles/layout";
+import { LayoutType} from '~/styles/layout';
 
 import './Playground.css';
 
@@ -17,16 +17,18 @@ const Playground = connect()((props: any) => {
   const { snippetID } = useParams();
   props.dispatch(newSnippetLoadDispatcher(snippetID));
 
-  return <div className="Playground">
-    <Header />
-    <Layout layout={LayoutType.Vertical}>
-      <FlexContainer>
-        <CodeEditor />
-      </FlexContainer>
-      <ResizablePreview layout={LayoutType.Vertical} collapsed={false} />
-    </Layout>
-    <StatusBar />
-  </div>;
+  return (
+    <div className="Playground">
+      <Header />
+      <Layout layout={LayoutType.Vertical}>
+        <FlexContainer>
+          <CodeEditor />
+        </FlexContainer>
+        <ResizablePreview layout={LayoutType.Vertical} collapsed={false} />
+      </Layout>
+      <StatusBar />
+    </div>
+  );
 });
 
 export default Playground;

--- a/web/src/components/pages/Playground.tsx
+++ b/web/src/components/pages/Playground.tsx
@@ -19,11 +19,11 @@ const Playground = connect()((props: any) => {
 
   return <div className="Playground">
     <Header />
-    <Layout layout={LayoutType.Vertical}>
+    <Layout layout={LayoutType.Horizontal}>
       <FlexContainer>
         <CodeEditor />
       </FlexContainer>
-      <ResizablePreview layout={LayoutType.Vertical} collapsed={false} />
+      <ResizablePreview layout={LayoutType.Horizontal} collapsed={false} />
     </Layout>
     <StatusBar />
   </div>;

--- a/web/src/components/pages/Playground.tsx
+++ b/web/src/components/pages/Playground.tsx
@@ -19,11 +19,11 @@ const Playground = connect()((props: any) => {
 
   return <div className="Playground">
     <Header />
-    <Layout layout={LayoutType.Horizontal}>
+    <Layout layout={LayoutType.Vertical}>
       <FlexContainer>
         <CodeEditor />
       </FlexContainer>
-      <ResizablePreview layout={LayoutType.Horizontal} collapsed={false} />
+      <ResizablePreview layout={LayoutType.Vertical} collapsed={false} />
     </Layout>
     <StatusBar />
   </div>;

--- a/web/src/components/preview/Preview.css
+++ b/web/src/components/preview/Preview.css
@@ -4,7 +4,7 @@
 }
 
 .app-preview__content {
-  padding: 15px;
+  padding: 0 15px 15px 15px;
   font-size: 10pt;
 }
 

--- a/web/src/components/preview/Preview.tsx
+++ b/web/src/components/preview/Preview.tsx
@@ -42,13 +42,15 @@ export default class Preview extends React.Component<PreviewProps> {
         </pre>
       </MessageBar>
     } else if (this.props.events) {
-      content = this.props.events.map((e, k) => <EvalEventView
-        key={k}
-        message={e.Message}
-        delay={e.Delay}
-        kind={e.Kind}
-        showDelay={!isWasm}
-      />);
+      content = this.props.events.map(({Message, Delay, Kind}, k) => (
+        <EvalEventView
+          key={k}
+          message={Message}
+          delay={Delay}
+          kind={Kind}
+          showDelay={!isWasm}
+        />
+      ));
 
       if (!isWasm) {
         content.push(<div className="app-preview__epilogue" key="exit">Program exited.</div>)

--- a/web/src/components/preview/ResizablePreview.css
+++ b/web/src/components/preview/ResizablePreview.css
@@ -29,7 +29,60 @@
   height: 1px;
 }
 
-/** Handles **/
+/** Handles - vertical **/
+.ResizablePreview__handle--left:before {
+  content: "";
+  position: absolute;
+  background: var(--pg-handle-default-color);
+  transition: background-color 0.1s ease-in 0s;
+  width: 1px;
+  height: 100%;
+  top: 0;
+  left: 50%;
+}
+
+.ResizablePreview__handle--left {
+  transition: background-color 0.1s ease-in 0s;
+}
+
+.ResizablePreview__handle--left:hover:before,
+.ResizablePreview__handle--left:active:before {
+  background: var(--pg-handle-active-color);
+  width: 3px;
+}
+
+@media (hover: none), (pointer: coarse) {
+  .ResizablePreview__handle--left {
+    background: black;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: #999;
+  }
+
+  .ResizablePreview__handle--left:hover,
+  .ResizablePreview__handle--left:active {
+    background: black;
+    color: white;
+  }
+
+  .ResizablePreview__handle--left:before {
+    display: none;
+  }
+
+  .ResizablePreview__handle--left:after {
+    content: "";
+    background: currentColor;
+    height: 13.3%;
+    width: 4px;
+    border-radius: 4px;
+    align-self: center;
+    transition: color 0.15s ease 0s;
+  }
+}
+
+/** Handles - Horizontal **/
 .ResizablePreview__handle--top:before {
   content: "";
   position: absolute;

--- a/web/src/components/preview/ResizablePreview.css
+++ b/web/src/components/preview/ResizablePreview.css
@@ -22,7 +22,7 @@
   background: var(--pg-handle-default-color);
 }
 
-.ResizablePreview.ResizablePreview--collapsed.ResizablePreview--horizontal:before {
+.ResizablePreview.ResizablePreview--collapsed.ResizablePreview--vertical:before {
   top: 0;
   left: 0;
   right: 0;

--- a/web/src/components/preview/ResizablePreview.css
+++ b/web/src/components/preview/ResizablePreview.css
@@ -105,7 +105,7 @@
   height: 3px;
 }
 
-/*@media (hover: none), (pointer: coarse) {*/
+@media (hover: none), (pointer: coarse) {
   .ResizablePreview__handle--top {
     background: black;
     display: flex;
@@ -135,4 +135,4 @@
     align-self: center;
     transition: 0.15s ease 0s;
   }
-/*}*/
+}

--- a/web/src/components/preview/ResizablePreview.css
+++ b/web/src/components/preview/ResizablePreview.css
@@ -71,9 +71,10 @@
 
   .ResizablePreview__handle--top:after {
     content: "";
-    background: #d3d3d3;
-    width: 25%;
-    height: 1px;
+    background: #999;
+    width: 86px;
+    height: 4px;
+    border-radius: 4px;
     align-self: center;
   }
 }

--- a/web/src/components/preview/ResizablePreview.css
+++ b/web/src/components/preview/ResizablePreview.css
@@ -74,7 +74,8 @@
   .ResizablePreview__handle--left:after {
     content: "";
     background: currentColor;
-    height: 13.3%;
+    height: 20%;
+    max-height: 80px;
     width: 4px;
     border-radius: 4px;
     align-self: center;
@@ -104,18 +105,20 @@
   height: 3px;
 }
 
-@media (hover: none), (pointer: coarse) {
+/*@media (hover: none), (pointer: coarse) {*/
   .ResizablePreview__handle--top {
     background: black;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    color: #999;
   }
 
   .ResizablePreview__handle--top:hover,
   .ResizablePreview__handle--top:active {
-    background: var(--pg-handle-active-color);
+    background: black;
+    color: #fff;
   }
 
   .ResizablePreview__handle--top:before {
@@ -124,10 +127,12 @@
 
   .ResizablePreview__handle--top:after {
     content: "";
-    background: #999;
-    width: 86px;
+    background: currentColor;
+    width: 20%;
+    max-width: 80px;
     height: 4px;
     border-radius: 4px;
     align-self: center;
+    transition: 0.15s ease 0s;
   }
-}
+/*}*/

--- a/web/src/components/preview/ResizablePreview.css
+++ b/web/src/components/preview/ResizablePreview.css
@@ -11,6 +11,25 @@
   padding: 10px 15px 0 15px;
 }
 
+/** Collapsed state **/
+.ResizablePreview.ResizablePreview--collapsed {
+  height: auto !important;
+}
+
+.ResizablePreview.ResizablePreview--collapsed:before {
+  content: "";
+  position: absolute;
+  background: var(--pg-handle-default-color);
+}
+
+.ResizablePreview.ResizablePreview--collapsed.ResizablePreview--horizontal:before {
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+}
+
+/** Handles **/
 .ResizablePreview__handle--top:before {
   content: "";
   position: absolute;

--- a/web/src/components/preview/ResizablePreview.css
+++ b/web/src/components/preview/ResizablePreview.css
@@ -7,6 +7,10 @@
   flex: 1 1 auto;
 }
 
+.ResizablePreview__controls {
+  padding: 10px 15px 0 15px;
+}
+
 .ResizablePreview__handle--top:before {
   content: "";
   position: absolute;

--- a/web/src/components/preview/ResizablePreview.tsx
+++ b/web/src/components/preview/ResizablePreview.tsx
@@ -28,14 +28,11 @@ const enabledCorners = {
 interface Props { }
 
 const ResizablePreview: React.FC<Props> = () => {
-  const {
-    palette: { accent },
-    semanticColors: { buttonBorder }
-  } = getTheme();
+  const {palette: { accent }, semanticColors: { buttonBorder }} = getTheme();
   const [height, setHeight] = useState(DEFAULT_HEIGHT_PX);
   const onResize = useCallback((e, direction, ref, d) => {
-    setHeight(height + d.height);
-  }, [setHeight, height]);
+    setHeight(prevValue => prevValue + d.height);
+  }, [setHeight]);
 
   return (
     <Resizable

--- a/web/src/components/preview/ResizablePreview.tsx
+++ b/web/src/components/preview/ResizablePreview.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useCallback } from 'react';
+import { VscSplitHorizontal, VscSplitVertical } from 'react-icons/vsc';
 import { getTheme } from '@fluentui/react';
 import { Resizable } from 're-resizable';
 
 import Preview from './Preview';
+import PanelHeader from "@components/core/Panel/PanelHeader";
 import './ResizablePreview.css';
 
 const DEFAULT_HEIGHT_PX = 300;
@@ -26,7 +28,10 @@ const enabledCorners = {
 interface Props { }
 
 const ResizablePreview: React.FC<Props> = () => {
-  const { palette: { accent }, semanticColors: { buttonBorder } } = getTheme();
+  const {
+    palette: { accent },
+    semanticColors: { buttonBorder }
+  } = getTheme();
   const [height, setHeight] = useState(DEFAULT_HEIGHT_PX);
   const onResize = useCallback((e, direction, ref, d) => {
     setHeight(height + d.height);
@@ -44,6 +49,21 @@ const ResizablePreview: React.FC<Props> = () => {
         '--pg-handle-default-color': buttonBorder,
       } as any}
     >
+      <PanelHeader
+        label="Output"
+        commands={{
+          'split-horizontally': {
+            hidden: true,
+            icon: <VscSplitVertical />,
+            label: 'Use horizontal layout'
+          },
+          'split-vertically': {
+            hidden: false,
+            icon: <VscSplitHorizontal />,
+            label: 'Use vertical layout'
+          }
+        }}
+      />
       <Preview />
     </Resizable>
   );

--- a/web/src/components/preview/ResizablePreview.tsx
+++ b/web/src/components/preview/ResizablePreview.tsx
@@ -15,7 +15,7 @@ import {LayoutType} from '~/styles/layout';
 import './ResizablePreview.css';
 
 const DEFAULT_HEIGHT_PX = 300;
-const DEFAULT_WIDTH_PX = 400;
+const DEFAULT_WIDTH_PX = 320;
 const MIN_HEIGHT = 36;
 const handleClasses = {
   top: 'ResizablePreview__handle--top',

--- a/web/src/components/preview/ResizablePreview.tsx
+++ b/web/src/components/preview/ResizablePreview.tsx
@@ -8,7 +8,7 @@ import PanelHeader from "@components/core/Panel/PanelHeader";
 import './ResizablePreview.css';
 
 const DEFAULT_HEIGHT_PX = 300;
-const DEFAULT_WIDTH = '100%';
+const DEFAULT_WIDTH_PX = 400;
 const handleClasses = {
   top: 'ResizablePreview__handle--top'
 }
@@ -25,20 +25,53 @@ const enabledCorners = {
   topLeft: false
 }
 
-interface Props { }
+export enum PanelLayout {
+  Horizontal = 'horizontal',
+  Vertical = 'vertical'
+}
 
-const ResizablePreview: React.FC<Props> = () => {
+interface Props {
+  layout?: PanelLayout
+}
+
+const ResizablePreview: React.FC<Props> = ({layout = PanelLayout.Horizontal}) => {
   const {palette: { accent }, semanticColors: { buttonBorder }} = getTheme();
   const [height, setHeight] = useState(DEFAULT_HEIGHT_PX);
-  const onResize = useCallback((e, direction, ref, d) => {
-    setHeight(prevValue => prevValue + d.height);
-  }, [setHeight]);
+  const [width, setWidth] = useState(DEFAULT_WIDTH_PX);
+  const onResize = useCallback((e, direction, ref, {height, width}) => {
+    switch (layout) {
+      case PanelLayout.Horizontal:
+        setHeight(prevValue => prevValue + height);
+        return;
+      case PanelLayout.Vertical:
+        setWidth(prevValue => prevValue + width);
+        return;
+      default:
+        return;
+    }
+  }, [setHeight, setWidth]);
+
+  const size = {
+    height: layout === PanelLayout.Horizontal ? height : '100%',
+    width: layout === PanelLayout.Vertical ? width : '100%'
+  };
+
+  const enabledCorners = {
+    top: layout === PanelLayout.Horizontal,
+    right: false,
+    bottom: false,
+    left: layout === PanelLayout.Vertical,
+    topRight: false,
+    bottomRight: false,
+    bottomLeft: false,
+    topLeft: false
+  };
 
   return (
     <Resizable
       className='ResizablePreview'
       handleClasses={handleClasses}
-      size={{ height, width: DEFAULT_WIDTH }}
+      size={size}
       enable={enabledCorners}
       onResizeStop={onResize}
       style={{

--- a/web/src/components/preview/ResizablePreview.tsx
+++ b/web/src/components/preview/ResizablePreview.tsx
@@ -7,7 +7,8 @@ import {
 } from 'react-icons/vsc';
 
 import Preview from './Preview';
-import PanelHeader from "@components/core/Panel/PanelHeader";
+import PanelHeader from '~/components/core/Panel/PanelHeader';
+import {LayoutType} from '~/styles/layout';
 import './ResizablePreview.css';
 
 const DEFAULT_HEIGHT_PX = 300;
@@ -18,26 +19,21 @@ const handleClasses = {
   left: 'ResizablePreview__handle--left',
 }
 
-export enum PanelLayout {
-  Horizontal = 'horizontal',
-  Vertical = 'vertical'
-}
-
 interface Props {
-  layout?: PanelLayout
+  layout?: LayoutType
 }
 
-const ResizablePreview: React.FC<Props> = ({layout = PanelLayout.Horizontal}) => {
+const ResizablePreview: React.FC<Props> = ({layout = LayoutType.Horizontal}) => {
   const {palette: { accent }, semanticColors: { buttonBorder }} = getTheme();
   const [height, setHeight] = useState(DEFAULT_HEIGHT_PX);
   const [width, setWidth] = useState(DEFAULT_WIDTH_PX);
   const [collapsed, setCollapsed] = useState(false);
   const onResize = useCallback((e, direction, ref, {height, width}) => {
     switch (layout) {
-      case PanelLayout.Horizontal:
+      case LayoutType.Horizontal:
         setHeight(prevValue => prevValue + height);
         return;
-      case PanelLayout.Vertical:
+      case LayoutType.Vertical:
         setWidth(prevValue => prevValue + width);
         return;
       default:
@@ -46,15 +42,15 @@ const ResizablePreview: React.FC<Props> = ({layout = PanelLayout.Horizontal}) =>
   }, [setHeight, setWidth, layout]);
 
   const size = {
-    height: layout === PanelLayout.Horizontal ? height : '100%',
-    width: layout === PanelLayout.Vertical ? width : '100%'
+    height: layout === LayoutType.Horizontal ? height : '100%',
+    width: layout === LayoutType.Vertical ? width : '100%'
   };
 
   const enabledCorners = {
-    top: !collapsed && layout === PanelLayout.Horizontal,
+    top: !collapsed && layout === LayoutType.Horizontal,
     right: false,
     bottom: false,
-    left: !collapsed && layout === PanelLayout.Vertical,
+    left: !collapsed && layout === LayoutType.Vertical,
     topRight: false,
     bottomRight: false,
     bottomLeft: false,

--- a/web/src/components/preview/ResizablePreview.tsx
+++ b/web/src/components/preview/ResizablePreview.tsx
@@ -100,6 +100,7 @@ const ResizablePreview: React.FC<Props> = ({
             onClick: () => onViewChange?.({ layout: LayoutType.Vertical })
           },
           'horizontal-layout': {
+            desktopOnly: true,
             hidden: layout === LayoutType.Horizontal,
             icon: <VscSplitHorizontal />,
             label: 'Use horizontal layout',

--- a/web/src/components/preview/ResizablePreview.tsx
+++ b/web/src/components/preview/ResizablePreview.tsx
@@ -11,11 +11,9 @@ import {
 
 import Preview from './Preview';
 import PanelHeader from '~/components/core/Panel/PanelHeader';
-import {LayoutType} from '~/styles/layout';
+import {LayoutType, DEFAULT_PANEL_HEIGHT, DEFAULT_PANEL_WIDTH} from '~/styles/layout';
 import './ResizablePreview.css';
 
-const DEFAULT_HEIGHT_PX = 300;
-const DEFAULT_WIDTH_PX = 320;
 const MIN_HEIGHT = 36;
 const handleClasses = {
   top: 'ResizablePreview__handle--top',
@@ -35,8 +33,8 @@ interface Props extends ResizePanelParams {
 
 const ResizablePreview: React.FC<Props> = ({
   layout = LayoutType.Vertical,
-  height = DEFAULT_HEIGHT_PX,
-  width=DEFAULT_WIDTH_PX,
+  height = DEFAULT_PANEL_HEIGHT,
+  width= DEFAULT_PANEL_WIDTH,
   collapsed,
   onViewChange
 }) => {

--- a/web/src/components/preview/ResizablePreview.tsx
+++ b/web/src/components/preview/ResizablePreview.tsx
@@ -1,7 +1,10 @@
 import React, { useState, useCallback } from 'react';
-import { VscSplitHorizontal, VscSplitVertical } from 'react-icons/vsc';
 import { getTheme } from '@fluentui/react';
 import { Resizable } from 're-resizable';
+import clsx from 'clsx';
+import {
+  VscSplitHorizontal, VscSplitVertical, VscChevronDown, VscChevronUp
+} from 'react-icons/vsc';
 
 import Preview from './Preview';
 import PanelHeader from "@components/core/Panel/PanelHeader";
@@ -9,20 +12,10 @@ import './ResizablePreview.css';
 
 const DEFAULT_HEIGHT_PX = 300;
 const DEFAULT_WIDTH_PX = 400;
+const MIN_HEIGHT = 36;
 const handleClasses = {
-  top: 'ResizablePreview__handle--top'
-}
-
-// re-resizable requires to implicitly mark disabled corners
-const enabledCorners = {
-  top: true,
-  right: false,
-  bottom: false,
-  left: false,
-  topRight: false,
-  bottomRight: false,
-  bottomLeft: false,
-  topLeft: false
+  top: 'ResizablePreview__handle--top',
+  left: 'ResizablePreview__handle--left',
 }
 
 export enum PanelLayout {
@@ -38,6 +31,7 @@ const ResizablePreview: React.FC<Props> = ({layout = PanelLayout.Horizontal}) =>
   const {palette: { accent }, semanticColors: { buttonBorder }} = getTheme();
   const [height, setHeight] = useState(DEFAULT_HEIGHT_PX);
   const [width, setWidth] = useState(DEFAULT_WIDTH_PX);
+  const [collapsed, setCollapsed] = useState(false);
   const onResize = useCallback((e, direction, ref, {height, width}) => {
     switch (layout) {
       case PanelLayout.Horizontal:
@@ -49,7 +43,7 @@ const ResizablePreview: React.FC<Props> = ({layout = PanelLayout.Horizontal}) =>
       default:
         return;
     }
-  }, [setHeight, setWidth]);
+  }, [setHeight, setWidth, layout]);
 
   const size = {
     height: layout === PanelLayout.Horizontal ? height : '100%',
@@ -57,10 +51,10 @@ const ResizablePreview: React.FC<Props> = ({layout = PanelLayout.Horizontal}) =>
   };
 
   const enabledCorners = {
-    top: layout === PanelLayout.Horizontal,
+    top: !collapsed && layout === PanelLayout.Horizontal,
     right: false,
     bottom: false,
-    left: layout === PanelLayout.Vertical,
+    left: !collapsed && layout === PanelLayout.Vertical,
     topRight: false,
     bottomRight: false,
     bottomLeft: false,
@@ -69,11 +63,18 @@ const ResizablePreview: React.FC<Props> = ({layout = PanelLayout.Horizontal}) =>
 
   return (
     <Resizable
-      className='ResizablePreview'
+      className={
+        clsx(
+          'ResizablePreview',
+          collapsed && 'ResizablePreview--collapsed',
+          `ResizablePreview--${layout}`
+        )
+      }
       handleClasses={handleClasses}
       size={size}
       enable={enabledCorners}
       onResizeStop={onResize}
+      minHeight={MIN_HEIGHT}
       style={{
         '--pg-handle-active-color': accent,
         '--pg-handle-default-color': buttonBorder,
@@ -82,6 +83,24 @@ const ResizablePreview: React.FC<Props> = ({layout = PanelLayout.Horizontal}) =>
       <PanelHeader
         label="Output"
         commands={{
+          'collapse': {
+            hidden: collapsed,
+            icon: <VscChevronDown />,
+            label: 'Collapse',
+            onClick: () => {
+              console.log('collapse!');
+              setCollapsed(true);
+            }
+          },
+          'expand': {
+            hidden: !collapsed,
+            icon: <VscChevronUp />,
+            label: 'Expand',
+            onClick: () => {
+              console.log('expand!');
+              setCollapsed(false);
+            }
+          },
           'split-horizontally': {
             hidden: true,
             icon: <VscSplitVertical />,
@@ -94,7 +113,9 @@ const ResizablePreview: React.FC<Props> = ({layout = PanelLayout.Horizontal}) =>
           }
         }}
       />
-      <Preview />
+      { collapsed ? null : (
+        <Preview />
+      )}
     </Resizable>
   );
 };

--- a/web/src/components/utils/ConnectedThemeProvider.tsx
+++ b/web/src/components/utils/ConnectedThemeProvider.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import {connect} from 'react-redux';
+import {ThemeProvider, ThemeProviderProps} from '@fluentui/react/lib/Theme';
+import { LightTheme, DarkTheme } from '~/services/colors';
+
+interface Props extends ThemeProviderProps {
+  darkMode?: boolean
+}
+
+const ConnectedThemeProvider: React.FunctionComponent<Props> = ({darkMode, children, ...props}) => (
+  <ThemeProvider theme={darkMode ? DarkTheme : LightTheme} {...props}>
+    {children}
+  </ThemeProvider>
+);
+
+export default connect(({settings: {darkMode}}: any) => ({darkMode}))(ConnectedThemeProvider);

--- a/web/src/services/config.ts
+++ b/web/src/services/config.ts
@@ -1,11 +1,14 @@
 import { loadTheme } from '@fluentui/react';
 import { DEFAULT_FONT } from './fonts';
 import { DarkTheme, LightTheme } from './colors';
+import {PanelState} from '~/store';
+import { defaultPanelProps } from '~/styles/layout';
 
 const DARK_THEME_KEY = 'ui.darkTheme.enabled';
 const RUNTIME_TYPE_KEY = 'go.build.runtime';
 const AUTOFORMAT_KEY = 'go.build.autoFormat';
 const MONACO_SETTINGS = 'ms.monaco.settings';
+const PANEL_SETTINGS = 'ui.layout.panel';
 
 
 export enum RuntimeType {
@@ -133,6 +136,43 @@ const Config = {
   set monacoSettings(m: MonacoSettings) {
     this._cache[MONACO_SETTINGS] = m;
     localStorage.setItem(MONACO_SETTINGS, JSON.stringify(m));
+  },
+
+  get panelLayout(): PanelState {
+    return this.getObject<PanelState>(PANEL_SETTINGS, {
+      ...defaultPanelProps,
+    })
+  },
+
+  set panelLayout(v: PanelState) {
+    this.saveObject(PANEL_SETTINGS, v);
+  },
+
+  saveObject<T>(key: string, value: T) {
+    localStorage.setItem(key, JSON.stringify(value));
+  },
+
+  getObject<T>(key: string, defaultVal: T): T {
+    if (this._cache[key]) {
+      return this._cache[key];
+    }
+
+    const val = localStorage.getItem(key);
+    if (!val) {
+      return defaultVal;
+    }
+
+    try {
+      const parsed = JSON.parse(val);
+      if (!parsed) {
+        return defaultVal;
+      }
+      this._cache[key] = parsed;
+      return parsed;
+
+    } catch (_) {
+      return defaultVal;
+    }
   },
 
   getValue<T>(key: string, defaultVal: T): T {

--- a/web/src/store/actions.ts
+++ b/web/src/store/actions.ts
@@ -1,5 +1,5 @@
 import {editor} from "monaco-editor";
-import { UIState } from './state';
+import {PanelState, UIState} from './state';
 import { RunResponse, EvalEvent } from '~/services/api';
 import { MonacoSettings, RuntimeType } from '~/services/config';
 
@@ -15,6 +15,7 @@ export enum ActionType {
   UI_STATE_CHANGE = 'UI_STATE_CHANGE',
   MARKER_CHANGE = 'MARKER_CHANGE',
   ENVIRONMENT_CHANGE = 'ENVIRONMENT_CHANGE',
+  PANEL_STATE_CHANGE = 'PANEL_STATE_CHANGE',
 
   // Special actions used by Go WASM bridge
   EVAL_START = 'EVAL_START',
@@ -112,5 +113,11 @@ export const newProgramWriteAction = (event: EvalEvent) =>
 export const newUIStateChangeAction = (changes: Partial<UIState>) =>
 ({
   type: ActionType.UI_STATE_CHANGE,
+  payload: changes
+});
+
+export const newPanelStateChangeAction = (changes: Partial<PanelState>) =>
+({
+  type: ActionType.PANEL_STATE_CHANGE,
   payload: changes
 });

--- a/web/src/store/dispatch.ts
+++ b/web/src/store/dispatch.ts
@@ -10,6 +10,7 @@ import {
   newImportFileAction,
   newLoadingAction,
   newMonacoParamsChangeAction,
+  newPanelStateChangeAction,
   newProgramWriteAction,
   newToggleThemeAction,
   newUIStateChangeAction
@@ -22,7 +23,7 @@ import client, {
 import config, {RuntimeType} from '~/services/config';
 import {DEMO_CODE} from '~/components/editor/props';
 import {getImportObject, goRun} from '~/services/go';
-import {State} from './state';
+import {PanelState, State} from './state';
 
 export type StateProvider = () => State
 export type DispatchFn = (a: Action | any) => any
@@ -175,6 +176,12 @@ export const dispatchToggleTheme: Dispatcher =
     dispatch(newToggleThemeAction())
   };
 
+export const dispatchPanelLayoutChange = (changes: Partial<PanelState>): Dispatcher => (
+  (dispatch: DispatchFn, _: StateProvider) => {
+    config.panelLayout = changes;
+    dispatch(newPanelStateChangeAction(changes));
+  }
+);
 
 //////////////////////////////////
 //          Adapters            //

--- a/web/src/store/reducers.ts
+++ b/web/src/store/reducers.ts
@@ -6,15 +6,16 @@ import { Action, ActionType, FileImportArgs, BuildParamsArgs, MonacoParamsChange
 import { RunResponse, EvalEvent } from '~/services/api';
 import localConfig, { MonacoSettings, RuntimeType } from '~/services/config'
 import { mapByAction } from './helpers';
-import config from "~/services/config";
+import config from '~/services/config';
+import {defaultPanelProps} from '~/styles/layout';
 import {
   EditorState,
   SettingsState,
   State,
   StatusState,
-  UIState
+  PanelState,
+  UIState,
 } from './state';
-
 
 const reducers = {
   editor: mapByAction<EditorState>({
@@ -97,6 +98,11 @@ const reducers = {
       return Object.assign({}, s, a.payload);
     }
   }, config.monacoSettings),
+  panel: mapByAction<PanelState>({
+    [ActionType.PANEL_STATE_CHANGE]: (s: PanelState, {payload}: Action<PanelState>) => ({
+      ...s, ...payload
+    })
+  }, config.panelLayout),
   ui: mapByAction<UIState>({
     [ActionType.LOADING]: (s: UIState, _: Action<Partial<UIState>>) => {
       if (!s) {
@@ -132,6 +138,7 @@ export const getInitialState = (): State => ({
     runtime: localConfig.runtimeType,
   },
   monaco: config.monacoSettings,
+  panel: defaultPanelProps
 });
 
 export const createRootReducer = history => combineReducers({

--- a/web/src/store/state.ts
+++ b/web/src/store/state.ts
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import {editor} from "monaco-editor";
 import { EvalEvent } from '~/services/api';
 import { MonacoSettings, RuntimeType } from '~/services/config';
+import {LayoutType} from '~/styles/layout';
 
 export interface UIState {
   shareCreated?: boolean
@@ -26,11 +27,19 @@ export interface SettingsState {
   runtime: RuntimeType,
 }
 
+export interface PanelState {
+  height ?: string|number
+  width ?: string|number
+  collapsed ?: boolean
+  layout?: LayoutType
+}
+
 export interface State {
   editor: EditorState
   status?: StatusState,
   settings: SettingsState
   monaco: MonacoSettings
+  panel: PanelState
   ui?: UIState
 }
 

--- a/web/src/styles/layout.ts
+++ b/web/src/styles/layout.ts
@@ -1,0 +1,4 @@
+export enum LayoutType {
+  Horizontal = 'horizontal',
+  Vertical = 'vertical'
+}

--- a/web/src/styles/layout.ts
+++ b/web/src/styles/layout.ts
@@ -5,3 +5,10 @@ export enum LayoutType {
 
 export const DEFAULT_PANEL_HEIGHT = 300;
 export const DEFAULT_PANEL_WIDTH = 320;
+export const DEFAULT_PANEL_LAYOUT = LayoutType.Vertical;
+
+export const defaultPanelProps = {
+  height: DEFAULT_PANEL_HEIGHT,
+  width: DEFAULT_PANEL_WIDTH,
+  layout: DEFAULT_PANEL_LAYOUT,
+};

--- a/web/src/styles/layout.ts
+++ b/web/src/styles/layout.ts
@@ -2,3 +2,6 @@ export enum LayoutType {
   Horizontal = 'horizontal',
   Vertical = 'vertical'
 }
+
+export const DEFAULT_PANEL_HEIGHT = 300;
+export const DEFAULT_PANEL_WIDTH = 320;

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -7424,6 +7424,11 @@ react-error-overlay@^6.0.10:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.10.tgz#0fe26db4fa85d9dbb8624729580e90e7159a59a6"
   integrity sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==
 
+react-icons@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.3.1.tgz#2fa92aebbbc71f43d2db2ed1aed07361124e91ca"
+  integrity sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==
+
 react-is@^16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3107,6 +3107,11 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"


### PR DESCRIPTION
This PR introduces vertical layout support which can be useful on wide screens.

Also this PR introduces some other useful things as side effect:

- Storing panel height/width in local storage
- Collapse/expand panel in horizontal mode.

Closes #136 

<img width="1218" alt="image" src="https://user-images.githubusercontent.com/9203548/162603500-ec97a1a2-e88e-4c9a-b927-e68e16c6025f.png">
