### PR TITLE
ui: add Shift+Enter and Ctrl+Shift+Enter commands to editor

### DIFF
--- a/web/src/components/editor/CodeEditor.tsx
+++ b/web/src/components/editor/CodeEditor.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import MonacoEditor from 'react-monaco-editor';
 import { editor } from 'monaco-editor';
 import * as monaco from 'monaco-editor';
+import { attachCustomCommands } from '@components/editor/commands';
 
 import {
   Connect,
@@ -74,8 +75,17 @@ export default class CodeEditor extends React.Component<any, CodeEditorState> {
       }
     ];
 
+    editorInstance.addCommand(
+      monaco.KeyMod.Shift | monaco.KeyCode.Enter,
+      (get) => {
+        const v = editorInstance.getAction('editor.action.insertLineAfter');
+        console.log({v, get: get.get('editor')});
+        v.run();
+      }
+    )
     // Register custom actions
-    actions.forEach(action => editorInstance.addAction(action))
+    actions.forEach(action => editorInstance.addAction(action));
+    attachCustomCommands(editorInstance);
     editorInstance.focus();
   }
 

--- a/web/src/components/editor/commands.ts
+++ b/web/src/components/editor/commands.ts
@@ -1,0 +1,38 @@
+import { editor } from 'monaco-editor';
+import * as monaco from "monaco-editor";
+
+/**
+ * MonacoDIContainer is undocumented DI service container of monaco editor.
+ */
+interface MonacoDIContainer {
+  get: <T>(svc) => T
+}
+
+interface HotkeyAction {
+  keybinding: number,
+  callback: (editorInstance: editor.IStandaloneCodeEditor, di?: MonacoDIContainer) => void
+}
+
+/**
+ * createActionAlias returns an action that triggers other monaco action.
+ * @param keybinding Hotkeys
+ * @param action Action name
+ */
+const createActionAlias = (keybinding: number, action: string): HotkeyAction => ({
+  keybinding, callback: (ed) => ed.getAction(action)?.run()
+})
+
+/**
+ * Builtin custom actions
+ */
+const commands: HotkeyAction[] = [
+  createActionAlias(
+    monaco.KeyMod.Shift | monaco.KeyCode.Enter,
+    'editor.action.insertLineAfter'
+  ),
+];
+
+export const attachCustomCommands = (editorInstance: editor.IStandaloneCodeEditor) => {
+  commands.forEach(({keybinding, callback}) =>
+    editorInstance.addCommand(keybinding, (di) => callback(editorInstance, di)))
+}

--- a/web/src/store/reducers.ts
+++ b/web/src/store/reducers.ts
@@ -7,7 +7,6 @@ import { RunResponse, EvalEvent } from '~/services/api';
 import localConfig, { MonacoSettings, RuntimeType } from '~/services/config'
 import { mapByAction } from './helpers';
 import config from '~/services/config';
-import {defaultPanelProps} from '~/styles/layout';
 import {
   EditorState,
   SettingsState,
@@ -16,7 +15,6 @@ import {
   PanelState,
   UIState,
 } from './state';
-import {supportsPreferColorScheme} from "~/utils/theme";
 
 const reducers = {
   editor: mapByAction<EditorState>({


### PR DESCRIPTION
This PR adds 2 new hotkeys to the editor:

* `Shift+Enter` - Insert new line after current line
* `Shift+Ctrl+Enter` - Insert new line before current line

Closes #157