### PR TITLE
Vim mode (#169)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "file-saver": "^2.0.5",
     "monaco-editor": "^0.33.0",
     "monaco-editor-webpack-plugin": "^7.0.1",
+    "monaco-vim": "^0.3.4",
     "re-resizable": "^6.9.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/web/src/components/core/StatusBar/StatusBar.tsx
+++ b/web/src/components/core/StatusBar/StatusBar.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
-import {editor} from "monaco-editor";
+import {editor} from 'monaco-editor';
+import {newEnvironmentChangeAction} from '~/store';
 import config, {RuntimeType} from '~/services/config';
 import EllipsisText from '~/components/utils/EllipsisText';
 import StatusBarItem from '~/components/core/StatusBar/StatusBarItem';
 import EnvironmentSelectModal from '~/components/modals/EnvironmentSelectModal';
-import {newEnvironmentChangeAction} from "~/store";
+import VimStatusBarItem from '~/plugins/vim/VimStatusBarItem';
 import './StatusBar.css';
 
 interface Props {
@@ -19,7 +20,7 @@ interface Props {
 const getStatusItem = ({loading, lastError}) => {
   if (loading) {
     return (
-      <StatusBarItem iconName="Build">
+      <StatusBarItem icon="Build">
         <EllipsisText>
           Loading
         </EllipsisText>
@@ -30,7 +31,7 @@ const getStatusItem = ({loading, lastError}) => {
   if (lastError) {
     return (
       <StatusBarItem
-        iconName="NotExecuted"
+        icon="NotExecuted"
         hideTextOnMobile
         disabled
       >
@@ -51,17 +52,18 @@ const StatusBar: React.FC<Props> = ({
       <div className={className}>
         <div className="StatusBar__side-left">
           <StatusBarItem
-            iconName="ErrorBadge"
+            icon="ErrorBadge"
             title="No Problems"
             button
           >
             {markers?.length ?? 0} Errors
           </StatusBarItem>
           {getStatusItem({loading, lastError})}
+          <VimStatusBarItem />
         </div>
         <div className="StatusBar__side-right">
           <StatusBarItem
-            iconName="Code"
+            icon="Code"
             title="Select environment"
             disabled={loading}
             onClick={() => setRunSelectorModalVisible(true)}
@@ -71,7 +73,7 @@ const StatusBar: React.FC<Props> = ({
             {RuntimeType.toString(runtime)}
           </StatusBarItem>
           <StatusBarItem
-            iconName="Feedback"
+            icon="Feedback"
             title="Send feedback"
             href={config.issueUrl}
             iconOnly

--- a/web/src/components/core/StatusBar/StatusBarItem.tsx
+++ b/web/src/components/core/StatusBar/StatusBarItem.tsx
@@ -2,12 +2,13 @@ import React, {CSSProperties, MouseEventHandler} from 'react';
 import { FontIcon } from '@fluentui/react/lib/Icon';
 import './StatusBarItem.css';
 
-interface Props {
-  iconName?: string
+export interface StatusBarItemProps {
+  icon?: string | React.ComponentType,
   iconOnly?: boolean
   imageSrc?: string
   button?: boolean
   disabled?: boolean
+  hidden?: boolean
   hideTextOnMobile?: boolean
   href?: string
   title?: string
@@ -15,12 +16,20 @@ interface Props {
   style?: CSSProperties
 }
 
-const getItemContents = ({iconName, iconOnly, imageSrc, title, children}) => (
+const getIcon = (icon: string | React.ComponentType) => (
+  typeof icon === 'string' ? (
+    <FontIcon iconName={icon} className="StatusBarItem__icon" />
+  ) : (
+    React.createElement<any>(icon as React.ComponentType, {
+      className: 'StatusBarItem__icon'
+    })
+  )
+)
+
+const getItemContents = ({icon, iconOnly, imageSrc, title, children}) => (
   <>
     {
-      iconName && (
-        <FontIcon iconName={iconName} className="StatusBarItem__icon"/>
-      )
+      icon && getIcon(icon)
     }
     {
       imageSrc && (
@@ -37,11 +46,23 @@ const getItemContents = ({iconName, iconOnly, imageSrc, title, children}) => (
   </>
 )
 
-const StatusBarItem: React.FC<Props> = ({
-  title, iconName, iconOnly, imageSrc, hideTextOnMobile,
-  href, button, children,  ...props
+const StatusBarItem: React.FC<StatusBarItemProps> = ({
+  title,
+  icon,
+  iconOnly,
+  imageSrc,
+  hideTextOnMobile,
+  href,
+  button,
+  children,
+  hidden,
+  ...props
 }) => {
-  const content = getItemContents({iconName, iconOnly, children, imageSrc, title});
+  if (hidden) {
+    return null;
+  }
+
+  const content = getItemContents({icon, iconOnly, children, imageSrc, title});
   const className = hideTextOnMobile ? (
     'StatusBarItem StatusBarItem--hideOnMobile'
   ) : 'StatusBarItem';

--- a/web/src/components/editor/CodeEditor.tsx
+++ b/web/src/components/editor/CodeEditor.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import MonacoEditor from 'react-monaco-editor';
-import { editor } from 'monaco-editor';
+import {editor, IKeyboardEvent} from 'monaco-editor';
 import * as monaco from 'monaco-editor';
-import { attachCustomCommands } from '@components/editor/commands';
+import {
+  VimModeKeymap,
+  createVimModeAdapter,
+  StatusBarAdapter
+} from '~/plugins/vim/editor';
+import { attachCustomCommands } from './commands';
 
 import {
   Connect,
@@ -13,7 +18,6 @@ import {
   newMarkerAction
 } from '~/store';
 import { Analyzer } from '~/services/analyzer';
-
 import { LANGUAGE_GOLANG, stateToOptions } from './props';
 
 const ANALYZE_DEBOUNCE_TIME = 500;
@@ -26,16 +30,33 @@ interface CodeEditorState {
 @Connect(s => ({
   code: s.editor.code,
   darkMode: s.settings.darkMode,
+  vimModeEnabled: s.settings.enableVimMode,
   loading: s.status?.loading,
   options: s.monaco,
+  vim: s.vim,
 }))
 export default class CodeEditor extends React.Component<any, CodeEditorState> {
-  analyzer?: Analyzer;
-  _previousTimeout: any;
-  editorInstance?: editor.IStandaloneCodeEditor;
+  private analyzer?: Analyzer;
+  private _previousTimeout: any;
+  private editorInstance?: editor.IStandaloneCodeEditor;
+  private vimAdapter?: VimModeKeymap;
+  private vimCommandAdapter?: StatusBarAdapter;
 
   editorDidMount(editorInstance: editor.IStandaloneCodeEditor, _: monaco.editor.IEditorConstructionOptions) {
     this.editorInstance = editorInstance;
+    editorInstance.onKeyDown(e => this.onKeyDown(e));
+    const [ vimAdapter, statusAdapter ] = createVimModeAdapter(
+      this.props.dispatch,
+      editorInstance
+    );
+    this.vimAdapter = vimAdapter;
+    this.vimCommandAdapter = statusAdapter;
+
+    if (this.props.vimModeEnabled) {
+      console.log('Vim mode enabled');
+      this.vimAdapter.attach();
+    }
+
     if (Analyzer.supported()) {
       this.analyzer = new Analyzer();
     } else {
@@ -81,11 +102,27 @@ export default class CodeEditor extends React.Component<any, CodeEditorState> {
     editorInstance.focus();
   }
 
-  componentWillUnmount() {
-    this.analyzer?.dispose();
+  componentDidUpdate(prevProps) {
+    if (prevProps?.vimModeEnabled === this.props.vimModeEnabled) {
+      return
+    }
+
+    if (this.props.vimModeEnabled) {
+      console.log('Vim mode enabled');
+      this.vimAdapter?.attach();
+      return;
+    }
+
+    console.log('Vim mode disabled');
+    this.vimAdapter?.dispose();
   }
 
-  onChange(newValue: string, e: editor.IModelContentChangedEvent) {
+  componentWillUnmount() {
+    this.analyzer?.dispose();
+    this.vimAdapter?.dispose();
+  }
+
+  onChange(newValue: string, _: editor.IModelContentChangedEvent) {
     this.props.dispatch(newFileChangeAction(newValue));
 
     if (this.analyzer) {
@@ -111,15 +148,26 @@ export default class CodeEditor extends React.Component<any, CodeEditorState> {
     }, ANALYZE_DEBOUNCE_TIME);
   }
 
+  private onKeyDown(e: IKeyboardEvent) {
+    const {vimModeEnabled, vim} = this.props;
+    if (!vimModeEnabled || !vim?.commandStarted) {
+      return;
+    }
+
+    this.vimCommandAdapter?.handleKeyDownEvent(e, vim?.keyBuffer);
+  }
+
   render() {
     const options = stateToOptions(this.props.options);
-    return <MonacoEditor
-      language={LANGUAGE_GOLANG}
-      theme={this.props.darkMode ? 'vs-dark' : 'vs-light'}
-      value={this.props.code}
-      options={options}
-      onChange={(newVal, e) => this.onChange(newVal, e)}
-      editorDidMount={(e, m: any) => this.editorDidMount(e, m)}
-    />;
+    return (
+      <MonacoEditor
+        language={LANGUAGE_GOLANG}
+        theme={this.props.darkMode ? 'vs-dark' : 'vs-light'}
+        value={this.props.code}
+        options={options}
+        onChange={(newVal, e) => this.onChange(newVal, e)}
+        editorDidMount={(e, m: any) => this.editorDidMount(e, m)}
+      />
+    );
   }
 }

--- a/web/src/components/settings/SettingsModal.tsx
+++ b/web/src/components/settings/SettingsModal.tsx
@@ -151,122 +151,62 @@ export default class SettingsModal extends ThemeableComponent<SettingsProps, Set
                 key='fontFamily'
                 title='Font Family'
                 description='Controls editor font family'
-                control={<Dropdown
-                  options={FONT_OPTS}
-                  defaultSelectedKey={this.props.monaco?.fontFamily ?? DEFAULT_FONT}
-                  onChange={(_, num) => {
-                    this.touchMonacoProperty('fontFamily', num?.key);
-                  }}
-                />}
+                control={(
+                  <Dropdown
+                    options={FONT_OPTS}
+                    defaultSelectedKey={this.props.monaco?.fontFamily ?? DEFAULT_FONT}
+                    onChange={(_, num) => {
+                      this.touchMonacoProperty('fontFamily', num?.key);
+                    }}
+                  />
+                )}
               />
               <SettingsProperty
                 key='autoDetectTheme'
                 title='Use System Theme'
-                control={<Checkbox
-                  label='Follow system dark mode preference instead of manual toggle.'
-                  defaultChecked={this.props.settings?.useSystemTheme}
-                  onChange={(_, val) => {
-                    this.touchSettingsProperty({
-                      useSystemTheme: val
-                    });
-                  }}
-                />}
+                control={(
+                  <Checkbox
+                    label='Follow system dark mode preference instead of manual toggle.'
+                    defaultChecked={this.props.settings?.useSystemTheme}
+                    onChange={(_, val) => {
+                      this.touchSettingsProperty({
+                        useSystemTheme: val
+                      });
+                    }}
+                  />
+                )}
               />
               <SettingsProperty
                 key='fontLigatures'
                 title='Font Ligatures'
-                control={<Checkbox
-                  label='Enable programming font ligatures in supported fonts'
-                  defaultChecked={this.props.monaco?.fontLigatures}
-                  onChange={(_, val) => {
-                    this.touchMonacoProperty('fontLigatures', val);
-                  }}
-                />}
+                control={(
+                  <Checkbox
+                    label='Enable programming font ligatures in supported fonts'
+                    defaultChecked={this.props.monaco?.fontLigatures}
+                    onChange={(_, val) => {
+                      this.touchMonacoProperty('fontLigatures', val);
+                    }}
+                  />
+                )}
               />
               <SettingsProperty
-                key='cursorBlinking'
-                title='Cursor Blinking'
-                description='Set cursor animation style'
-                control={<Dropdown
-                  options={CURSOR_BLINK_STYLE_OPTS}
-                  defaultSelectedKey={this.props.monaco?.cursorBlinking}
-                  onChange={(_, num) => {
-                    this.touchMonacoProperty('cursorBlinking', num?.key);
-                  }}
-                />}
-              />
-              <SettingsProperty
-                key='cursorStyle'
-                title='Cursor Style'
-                description='Set the cursor style'
-                control={<Dropdown
-                  options={CURSOR_LINE_OPTS}
-                  defaultSelectedKey={this.props.monaco?.cursorStyle}
-                  onChange={(_, num) => {
-                    this.touchMonacoProperty('cursorStyle', num?.key);
-                  }}
-                />}
-              />
-              <SettingsProperty
-                key='selectOnLineNumbers'
-                title='Select On Line Numbers'
-                control={<Checkbox
-                  label="Select corresponding line on line number click"
-                  defaultChecked={this.props.monaco?.selectOnLineNumbers}
-                  onChange={(_, val) => {
-                    this.touchMonacoProperty('cursorStyle', val);
-                  }}
-                />}
-              />
-              <SettingsProperty
-                key='minimap'
-                title='Mini Map'
-                control={<Checkbox
-                  label="Enable mini map on side"
-                  defaultChecked={this.props.monaco?.minimap}
-                  onChange={(_, val) => {
-                    this.touchMonacoProperty('minimap', val);
-                  }}
-                />}
-              />
-              <SettingsProperty
-                key='contextMenu'
-                title='Context Menu'
-                control={<Checkbox
-                  label="Enable editor context menu (on right click)"
-                  defaultChecked={this.props.monaco?.contextMenu}
-                  onChange={(_, val) => {
-                    this.touchMonacoProperty('contextMenu', val);
-                  }}
-                />}
-              />
-              <SettingsProperty
-                key='smoothScroll'
-                title='Smooth Scrolling'
-                control={<Checkbox
-                  label="Enable that the editor animates scrolling to a position"
-                  defaultChecked={this.props.monaco?.smoothScrolling}
-                  onChange={(_, val) => {
-                    this.touchMonacoProperty('smoothScrolling', val);
-                  }}
-                />}
-              />
-              <SettingsProperty
-                key='mouseWheelZoom'
-                title='Mouse Wheel Zoom'
-                control={<Checkbox
-                  label="Zoom the font in the editor when using the mouse wheel in combination with holding Ctrl"
-                  defaultChecked={this.props.monaco?.mouseWheelZoom}
-                  onChange={(_, val) => {
-                    this.touchMonacoProperty('mouseWheelZoom', val);
-                  }}
-                />}
+                key='enableVimMode'
+                title='Enable Vim Mode'
+                control={(
+                  <Checkbox
+                    label='Allows to use Vim key bindings when editing'
+                    defaultChecked={this.props.settings?.enableVimMode}
+                    onChange={(_, val) => {
+                      this.touchSettingsProperty({enableVimMode: val})
+                    }}
+                  />
+                )}
               />
             </PivotItem>
-            <PivotItem headerText='Build' style={{ paddingBottom: '64px' }}>
+            <PivotItem headerText='Go Environment' style={{ paddingBottom: '64px' }}>
               <SettingsProperty
                 key='runtime'
-                title='Runtime'
+                title='Environment'
                 description='This option lets you choose where your Go code should be executed.'
                 control={<Dropdown
                   options={COMPILER_OPTIONS}
@@ -320,6 +260,101 @@ export default class SettingsModal extends ThemeableComponent<SettingsProps, Set
                     };
                   }}
                 />}
+              />
+            </PivotItem>
+            <PivotItem headerText='Advanced'>
+              <SettingsProperty
+                key='cursorBlinking'
+                title='Cursor Blinking'
+                description='Set cursor animation style'
+                control={(
+                  <Dropdown
+                    options={CURSOR_BLINK_STYLE_OPTS}
+                    defaultSelectedKey={this.props.monaco?.cursorBlinking}
+                    onChange={(_, num) => {
+                      this.touchMonacoProperty('cursorBlinking', num?.key);
+                    }}
+                  />
+                )}
+              />
+              <SettingsProperty
+                key='cursorStyle'
+                title='Cursor Style'
+                description='Set the cursor style'
+                control={(
+                  <Dropdown
+                    options={CURSOR_LINE_OPTS}
+                    defaultSelectedKey={this.props.monaco?.cursorStyle}
+                    onChange={(_, num) => {
+                      this.touchMonacoProperty('cursorStyle', num?.key);
+                    }}
+                  />
+                )}
+              />
+              <SettingsProperty
+                key='selectOnLineNumbers'
+                title='Select On Line Numbers'
+                control={(
+                  <Checkbox
+                    label="Select corresponding line on line number click"
+                    defaultChecked={this.props.monaco?.selectOnLineNumbers}
+                    onChange={(_, val) => {
+                      this.touchMonacoProperty('cursorStyle', val);
+                    }}
+                  />
+                )}
+              />
+              <SettingsProperty
+                key='minimap'
+                title='Mini Map'
+                control={(
+                  <Checkbox
+                    label="Enable mini map on side"
+                    defaultChecked={this.props.monaco?.minimap}
+                    onChange={(_, val) => {
+                      this.touchMonacoProperty('minimap', val);
+                    }}
+                  />
+                )}
+              />
+              <SettingsProperty
+                key='contextMenu'
+                title='Context Menu'
+                control={(
+                  <Checkbox
+                    label="Enable editor context menu (on right click)"
+                    defaultChecked={this.props.monaco?.contextMenu}
+                    onChange={(_, val) => {
+                      this.touchMonacoProperty('contextMenu', val);
+                    }}
+                  />
+                )}
+              />
+              <SettingsProperty
+                key='smoothScroll'
+                title='Smooth Scrolling'
+                control={(
+                  <Checkbox
+                    label="Enable that the editor animates scrolling to a position"
+                    defaultChecked={this.props.monaco?.smoothScrolling}
+                    onChange={(_, val) => {
+                      this.touchMonacoProperty('smoothScrolling', val);
+                    }}
+                  />
+                )}
+              />
+              <SettingsProperty
+                key='mouseWheelZoom'
+                title='Mouse Wheel Zoom'
+                control={(
+                  <Checkbox
+                    label="Zoom the font in the editor when using the mouse wheel in combination with holding Ctrl"
+                    defaultChecked={this.props.monaco?.mouseWheelZoom}
+                    onChange={(_, val) => {
+                      this.touchMonacoProperty('mouseWheelZoom', val);
+                    }}
+                  />
+                )}
               />
             </PivotItem>
           </Pivot>

--- a/web/src/components/utils/SharePopup.tsx
+++ b/web/src/components/utils/SharePopup.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext, useMemo} from 'react';
+import React, {FC, useMemo} from 'react';
 import copy from 'copy-to-clipboard';
 import { Target } from '@fluentui/react-hooks';
 import {

--- a/web/src/plugins/vim/VimStatusBarItem.tsx
+++ b/web/src/plugins/vim/VimStatusBarItem.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { SiVim } from 'react-icons/si';
+import { State } from '~/store';
+import { Nullable } from '~/utils/types';
+import { VimMode, VimState, VimSubMode } from '~/store/vim/state';
+import StatusBarItem from '~/components/core/StatusBar/StatusBarItem';
+
+interface Props {
+  vimState?: Nullable<VimState>
+}
+
+const getItemText = (state: Nullable<VimState>): Nullable<string> => {
+  if (!state) return null;
+  const { mode, subMode, keyBuffer, commandStarted, confirmMessage } = state;
+  if (confirmMessage) {
+    return confirmMessage;
+  }
+
+  if (commandStarted) {
+    return keyBuffer!;
+  }
+
+  if (mode !== VimMode.Visual) {
+    return `-- ${mode.toUpperCase()} --`;
+  }
+
+  switch (subMode) {
+    case VimSubMode.Linewise:
+      return '-- VISUAL LINE --';
+    case VimSubMode.Blockwise:
+      return '-- VISUAL BLOCK --';
+    default:
+      return '-- VISUAL --';
+  }
+}
+
+const VimStatusBarItem: React.FC<Props> = ({vimState}) => {
+  if (!vimState) {
+    return null;
+  }
+
+  return (
+    <StatusBarItem
+      title="Vim Status"
+      icon={SiVim}
+    >
+      {getItemText(vimState)}
+    </StatusBarItem>
+  )
+}
+
+export default connect(
+  ({vim}: State) => ({ vimState: vim})
+)(VimStatusBarItem);

--- a/web/src/plugins/vim/editor.ts
+++ b/web/src/plugins/vim/editor.ts
@@ -1,0 +1,150 @@
+import {editor, IKeyboardEvent, KeyCode} from 'monaco-editor';
+import VimModeKeymap from 'monaco-vim/lib/cm/keymap_vim';
+import {Dispatch} from '~/store/vim/state';
+
+import {
+  newVimCommandDoneAction,
+  newVimCommandStartAction,
+  newVimConfirmAction,
+  newVimDisposeAction,
+  newVimInitAction, newVimKeyDeleteAction,
+  newVimKeyPressAction,
+  newVimModeChangeAction,
+  VimModeChangeArgs
+} from '~/store/vim/actions';
+import {Nullable} from "~/utils/types";
+
+// This implementation is quite hacky, but still better than
+// having a huge list of all possible keys except printable.
+const regularKeyRegex = /^.$/;
+const isPrintableKey = (key: string) => regularKeyRegex.test(key);
+
+interface CommandInputOpts {
+  bottom?: boolean,
+  selectValueOnOpen?: boolean,
+  closeOnEnter?: boolean,
+  onKeyDown?: (e: KeyboardEvent, input: HTMLInputElement, closeFn: Function) => void
+  onKeyUp?: (e: KeyboardEvent, input: HTMLInputElement, closeFn: Function) => void,
+  value: string
+}
+
+class VimModeKeymapAdapter extends VimModeKeymap {
+  constructor(
+    // "dispatch" is reserved method in inner class.
+    private dispatchFunc: Dispatch,
+    editorInstance: editor.IStandaloneCodeEditor
+  ) {
+    super(editorInstance);
+  }
+
+  attach() {
+    this.dispatchFunc(newVimInitAction());
+    super.attach();
+  }
+}
+
+export { VimModeKeymap };
+
+export class StatusBarAdapter {
+  private commandResultCallback?: Nullable<((val: string) => void)>;
+  private currentOpts?: Nullable<CommandInputOpts>;
+
+  constructor(
+    private dispatchFn: Dispatch,
+    private editor: editor.IStandaloneCodeEditor
+  ) {}
+
+  /**
+   * Method called on command result, usually an error.
+   *
+   * Library passes pre-formated styled HTML element for display.
+   * @param result
+   */
+  showNotification(result: string|HTMLElement) {
+    const msg = result instanceof HTMLElement ? result.innerText : result;
+    console.log('showNotification', msg);
+    this.dispatchFn(newVimConfirmAction(msg));
+    this.commandResultCallback = null;
+  }
+
+  /**
+   * Called by VimModeKeymap on command start
+   * @param text DocumentFragment which contains info about command character
+   * @param callback Callback to submit command
+   * @param options Command handle arguments (unused)
+   */
+  setSec(text: DocumentFragment, callback: (val: string) => void, options: CommandInputOpts) {
+    this.currentOpts = options;
+    this.commandResultCallback = callback;
+
+    // Initial character is hidden inside an array of 2 spans as content of 1 span.
+    // Idk who thought that this is a good idea, but we have to deal with it.
+    const commandChar = text.firstChild?.textContent;
+    this.dispatchFn(newVimCommandStartAction(commandChar));
+  }
+
+  onPromptClose(value: string) {
+    this.commandResultCallback?.(value.substring(1));
+    this.commandResultCallback = null;
+  }
+
+  handleKeyDownEvent(e: IKeyboardEvent, currentData: string) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    switch (e.keyCode) {
+      case KeyCode.Enter:
+        this.onPromptClose(currentData);
+        return;
+      case KeyCode.Backspace:
+        this.dispatchFn(newVimKeyDeleteAction());
+        return;
+      default:
+        break;
+    }
+
+    if (isPrintableKey(e.browserEvent.key)) {
+      this.dispatchFn(newVimKeyPressAction(e.browserEvent.key));
+    }
+  }
+
+  private closeInput() {
+    console.log('clear input');
+    // this?.inputRef.current?.blur();
+    this?.editor?.focus();
+    this.currentOpts = null;
+    // this.commandResultCallback = null;
+  }
+}
+
+/**
+ * Creates a vim-mode adapter attached to state dispatcher and editor instance
+ * @param dispatch State dispatch function
+ * @param editorInstance Monaco editor instance
+ */
+export const createVimModeAdapter = (
+  dispatch: Dispatch,
+  editorInstance: editor.IStandaloneCodeEditor
+): [VimModeKeymap, StatusBarAdapter] => {
+  const vimAdapter: VimModeKeymap = new VimModeKeymapAdapter(dispatch, editorInstance);
+  const statusAdapter = new StatusBarAdapter(dispatch, editorInstance);
+
+  vimAdapter.setStatusBar(statusAdapter);
+  vimAdapter.on('vim-mode-change', (mode: VimModeChangeArgs) => {
+    dispatch(newVimModeChangeAction(mode));
+  });
+
+  vimAdapter.on('vim-keypress', (key: string) => {
+    dispatch(newVimKeyPressAction(key));
+  });
+
+  vimAdapter.on('vim-command-done', () => {
+    dispatch(newVimCommandDoneAction());
+  });
+
+  vimAdapter.on('dispose', () => {
+    dispatch(newVimDisposeAction());
+  });
+
+  return [vimAdapter, statusAdapter];
+};

--- a/web/src/services/config.ts
+++ b/web/src/services/config.ts
@@ -8,6 +8,7 @@ import {supportsPreferColorScheme} from "~/utils/theme";
 const DARK_THEME_KEY = 'ui.darkTheme.enabled';
 const USE_SYSTEM_THEME_KEY = 'ui.darkTheme.useSystem';
 const RUNTIME_TYPE_KEY = 'go.build.runtime';
+const ENABLE_VIM_MODE_KEY = 'ms.monaco.vimModeEnabled';
 const AUTOFORMAT_KEY = 'go.build.autoFormat';
 const MONACO_SETTINGS = 'ms.monaco.settings';
 const PANEL_SETTINGS = 'ui.layout.panel';
@@ -101,6 +102,19 @@ const Config = {
   set useSystemTheme(val: boolean) {
     this._cache[USE_SYSTEM_THEME_KEY] = val;
     localStorage.setItem(USE_SYSTEM_THEME_KEY, val.toString());
+  },
+
+  get enableVimMode() {
+    if (this._cache[ENABLE_VIM_MODE_KEY]) {
+      return this._cache[ENABLE_VIM_MODE_KEY];
+    }
+
+    return this.getBoolean(ENABLE_VIM_MODE_KEY, false);
+  },
+
+  set enableVimMode(val: boolean) {
+    this._cache[ENABLE_VIM_MODE_KEY] = val;
+    localStorage.setItem(ENABLE_VIM_MODE_KEY, val.toString());
   },
 
   get runtimeType(): RuntimeType {

--- a/web/src/store/actions.ts
+++ b/web/src/store/actions.ts
@@ -24,8 +24,8 @@ export enum ActionType {
   EVAL_FINISH = 'EVAL_FINISH'
 }
 
-export interface Action<T = any> {
-  type: ActionType
+export interface Action<T = any, A = ActionType> {
+  type: A
   payload: T
 }
 

--- a/web/src/store/dispatch.ts
+++ b/web/src/store/dispatch.ts
@@ -77,6 +77,10 @@ export const newSettingsChangeDispatcher = (changes: Partial<SettingsState>): Di
       config.darkThemeEnabled = !!changes.darkMode;
     }
 
+    if ('enableVimMode' in changes) {
+      config.enableVimMode = !!changes.enableVimMode;
+    }
+
     dispatch(newSettingsChangeAction(changes));
   }
 );
@@ -88,7 +92,6 @@ export function newBuildParamsChangeDispatcher(runtime: RuntimeType, autoFormat:
     dispatch(newBuildParamsChangeAction(runtime, autoFormat));
   };
 }
-
 
 export function newSnippetLoadDispatcher(snippetID?: string): Dispatcher {
   return async (dispatch: DispatchFn, _: StateProvider) => {

--- a/web/src/store/reducers.ts
+++ b/web/src/store/reducers.ts
@@ -1,12 +1,14 @@
 import { connectRouter } from 'connected-react-router';
 import { combineReducers } from 'redux';
-import {editor} from "monaco-editor";
+import {editor} from 'monaco-editor';
 
-import { Action, ActionType, FileImportArgs, BuildParamsArgs, MonacoParamsChanges } from './actions';
 import { RunResponse, EvalEvent } from '~/services/api';
-import localConfig, { MonacoSettings, RuntimeType } from '~/services/config'
+import config, { MonacoSettings, RuntimeType } from '~/services/config'
+
+import vimReducers from './vim/reducers';
+import { Action, ActionType, FileImportArgs, BuildParamsArgs, MonacoParamsChanges } from './actions';
 import { mapByAction } from './helpers';
-import config from '~/services/config';
+
 import {
   EditorState,
   SettingsState,
@@ -82,7 +84,7 @@ const reducers = {
   settings: mapByAction<SettingsState>({
     [ActionType.TOGGLE_THEME]: (s: SettingsState, a: Action) => {
       s.darkMode = !s.darkMode;
-      localConfig.darkThemeEnabled = s.darkMode;
+      config.darkThemeEnabled = s.darkMode;
       return s;
     },
     [ActionType.BUILD_PARAMS_CHANGE]: (s: SettingsState, a: Action<BuildParamsArgs>) => {
@@ -95,10 +97,11 @@ const reducers = {
       ...s, ...payload
     })
   }, {
-    darkMode: localConfig.darkThemeEnabled,
+    darkMode: config.darkThemeEnabled,
     autoFormat: true,
     runtime: RuntimeType.GoPlayground,
-    useSystemTheme: localConfig.useSystemTheme,
+    useSystemTheme: config.useSystemTheme,
+    enableVimMode: config.enableVimMode
   }),
   monaco: mapByAction<MonacoSettings>({
     [ActionType.MONACO_SETTINGS_CHANGE]: (s: MonacoSettings, a: Action<MonacoParamsChanges>) => {
@@ -128,7 +131,8 @@ const reducers = {
 
       return { ...s, ...payload };
     }
-  }, {})
+  }, {}),
+  vim: vimReducers
 };
 
 export const getInitialState = (): State => ({
@@ -140,13 +144,15 @@ export const getInitialState = (): State => ({
     code: ''
   },
   settings: {
-    darkMode: localConfig.darkThemeEnabled,
-    autoFormat: localConfig.autoFormat,
-    runtime: localConfig.runtimeType,
-    useSystemTheme: localConfig.useSystemTheme,
+    darkMode: config.darkThemeEnabled,
+    autoFormat: config.autoFormat,
+    runtime: config.runtimeType,
+    useSystemTheme: config.useSystemTheme,
+    enableVimMode: config.enableVimMode
   },
   monaco: config.monacoSettings,
-  panel: localConfig.panelLayout
+  panel: config.panelLayout,
+  vim: null
 });
 
 export const createRootReducer = history => combineReducers({

--- a/web/src/store/state.ts
+++ b/web/src/store/state.ts
@@ -3,6 +3,7 @@ import {editor} from "monaco-editor";
 import { EvalEvent } from '~/services/api';
 import { MonacoSettings, RuntimeType } from '~/services/config';
 import {LayoutType} from '~/styles/layout';
+import { VimState } from '~/store/vim/state';
 
 export interface UIState {
   shareCreated?: boolean
@@ -26,6 +27,7 @@ export interface SettingsState {
   useSystemTheme: boolean
   autoFormat: boolean,
   runtime: RuntimeType,
+  enableVimMode: boolean
 }
 
 export interface PanelState {
@@ -42,6 +44,7 @@ export interface State {
   monaco: MonacoSettings
   panel: PanelState
   ui?: UIState
+  vim?: VimState | null
 }
 
 export function Connect(fn: (state: State) => any) {

--- a/web/src/store/vim/actions.ts
+++ b/web/src/store/vim/actions.ts
@@ -1,0 +1,61 @@
+import { VimState } from '~/store/vim/state';
+import {Nullable} from "~/utils/types";
+
+export enum ActionType {
+  VIM_INIT = 'VIM_INIT',
+  VIM_DISPOSE = 'VIM_DISPOSE',
+  VIM_MODE_CHANGE = 'VIM_MODE_CHANGE',
+  VIM_KEYPRESS = 'VIM_KEYPRESS',
+  VIM_KEYDEL = 'VIM_KEYDEL',
+  VIM_COMMAND_START = 'VIM_COMMAND_START',
+  VIM_COMMAND_DONE = 'VIM_COMMAND_DONE',
+  VIM_SHOW_CONFIRM = 'VIM_SHOW_CONFIRM'
+}
+
+/**
+ * VimModeChangeArgs represents current selected mode and sub-mode.
+ *
+ * @see monaco-vim/lib/statusbar.js
+ */
+export type VimModeChangeArgs = Pick<VimState, 'mode' | 'subMode'>;
+
+export interface VimKeyPressArgs {
+  key: string
+  replaceContents: boolean
+}
+
+export const newVimInitAction = () => ({
+  type: ActionType.VIM_INIT
+});
+
+export const newVimDisposeAction = () => ({
+  type: ActionType.VIM_DISPOSE
+});
+
+export const newVimModeChangeAction = (payload: VimModeChangeArgs) => ({
+  type: ActionType.VIM_MODE_CHANGE,
+  payload
+});
+
+export const newVimKeyPressAction = (key: string, replaceContents = false) => ({
+  type: ActionType.VIM_KEYPRESS,
+  payload: {key, replaceContents}
+});
+
+export const newVimKeyDeleteAction = () => ({
+  type: ActionType.VIM_KEYDEL
+});
+
+export const newVimCommandStartAction = (commandSuffix?: Nullable<string>) => ({
+  type: ActionType.VIM_COMMAND_START,
+  payload: commandSuffix ?? ''
+})
+
+export const newVimCommandDoneAction = () => ({
+  type: ActionType.VIM_COMMAND_DONE
+});
+
+export const newVimConfirmAction = (msg: string) => ({
+  type: ActionType.VIM_SHOW_CONFIRM,
+  payload: msg
+});

--- a/web/src/store/vim/reducers.ts
+++ b/web/src/store/vim/reducers.ts
@@ -1,0 +1,57 @@
+import { mapByAction} from '~/store/helpers';
+import { Nullable } from '~/utils/types';
+import { Action } from '~/store/actions';
+import { VimState, VimMode } from './state';
+import {ActionType, VimKeyPressArgs, VimModeChangeArgs} from './actions';
+
+const initialState: VimState = { mode: VimMode.Normal }
+
+const reducers = mapByAction<Nullable<VimState>>({
+  [ActionType.VIM_INIT]: () => initialState,
+  [ActionType.VIM_DISPOSE]: () => null,
+  [ActionType.VIM_MODE_CHANGE]: (s: Nullable<VimState>, {payload: {mode, subMode}}: Action<VimModeChangeArgs>) => (
+    s ? { ...s, mode, subMode} : { mode, subMode }
+  ),
+  [ActionType.VIM_KEYPRESS]: (s: Nullable<VimState>, {payload: {key, replaceContents}}: Action<VimKeyPressArgs>) => {
+    const state = s ?? initialState;
+    if (!state.commandStarted) {
+      return state;
+    }
+
+    const { keyBuffer } = state;
+    const newContent = replaceContents ? key : keyBuffer + key;
+    return { ...state, commandStarted: true, keyBuffer: newContent};
+  },
+  [ActionType.VIM_KEYDEL]: (s: Nullable<VimState>) => {
+    const state = s ?? initialState;
+    const keyBuffer = state.keyBuffer?.slice(0, -1);
+    if (!keyBuffer) {
+      const { mode, subMode } = state;
+      return { mode, subMode };
+    }
+
+    return { ...state, keyBuffer};
+  },
+  [ActionType.VIM_COMMAND_START]: (s: Nullable<VimState>, {payload}: Action<string>) => {
+    const state = s ?? initialState;
+    const { mode, subMode } = state;
+    return { mode, subMode, commandStarted: true, keyBuffer: payload ?? ''};
+  },
+  [ActionType.VIM_COMMAND_DONE]: (s: Nullable<VimState>) => {
+    if (!s) {
+      return initialState;
+    }
+
+    const { mode, subMode } = s;
+    return { mode, subMode };
+  },
+  [ActionType.VIM_SHOW_CONFIRM]: (s: Nullable<VimState>, {payload}: Action<string>) => {
+    const {mode, subMode} = s ?? initialState;
+    return {
+      mode, subMode,
+      confirmMessage: payload,
+    }
+  }
+}, null);
+
+export default reducers;

--- a/web/src/store/vim/state.ts
+++ b/web/src/store/vim/state.ts
@@ -1,0 +1,21 @@
+export enum VimMode {
+  Visual = 'visual',
+  Normal = 'normal',
+  Insert = 'insert',
+  Replace = 'replace'
+}
+
+export enum VimSubMode {
+  Linewise = 'linewise',
+  Blockwise = 'blockwise'
+}
+
+export type Dispatch = <V=any,T=string>(v:{type: T, payload?: V}) => void;
+
+export interface VimState {
+  mode: VimMode
+  subMode?: VimSubMode
+  keyBuffer?: string
+  commandStarted?: boolean
+  confirmMessage?: string
+}

--- a/web/src/types/monaco-vim/index.d.ts
+++ b/web/src/types/monaco-vim/index.d.ts
@@ -1,0 +1,38 @@
+import { editor } from 'monaco-editor';
+
+type Mode = 'visual' | 'normal' | 'insert' | 'replace';
+
+interface StatusBar {
+  setMode(mode: Mode)
+  setSec(html: string, callback: () => void, options: any)
+  showNotification(html: string)
+  setKeyBuffer(val: string)
+  setText(txt: string)
+  toggleVisibility(isVisible: boolean)
+  closeInput()
+  clear()
+}
+
+declare module 'monaco-vim/lib/cm/keymap_vim' {
+  type Callback<T> = (val: T) => void;
+  export default class VimMode {
+    constructor(editorInstance: editor.IStandaloneCodeEditor, statusBar?: StatusBar);
+    on(eventName: 'vim-mode-change', cb: Callback<{mode: Mode, subMode?: string}>);
+    on(eventName: 'vim-keypress', cb: Callback<string>);
+    on(eventName: 'vim-command-done', cb: () => void);
+    on(eventName: 'dispose', cb: () => void);
+    setStatusBar(bar: StatusBar);
+    attach();
+    dispose();
+  }
+}
+
+declare module 'monaco-vim' {
+  export { StatusBar };
+  export default function initVimMode(
+    editorInstance: editor.IStandaloneCodeEditor,
+    statusBarNode?: HTMLElement | null = null,
+    StatusBarClass?: StatusBar,
+    sanitizer?: (val: string) => string
+  );
+}

--- a/web/src/utils/types.ts
+++ b/web/src/utils/types.ts
@@ -1,0 +1,24 @@
+export type Nullable<T> = T | null;
+
+/**
+ * Returns a new object without specified keys
+ * @param obj Object
+ * @param keys List of keys to exclude
+ */
+export const excludeKeys = <T = any, R = Partial<T>>(obj: T, ...keys: Array<keyof T>): R => {
+  if (!obj) return (obj as unknown) as R;
+  switch (keys.length) {
+    case 0:
+      return (obj as unknown) as R;
+    case 1:
+      const newObj = { ...obj };
+      const [ key ] = keys;
+      delete newObj[key];
+      return (obj as unknown) as R;
+    default:
+      const keysList = new Set(keys as string[]);
+      return Object.fromEntries(
+        Object.entries(obj).filter(([key]) => !keysList.has(key))
+      ) as R;
+  }
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -22,6 +22,10 @@
     "noImplicitAny": false,
     "experimentalDecorators": true,
     "noFallthroughCasesInSwitch": true,
+    "typeRoots": [
+      "src/types/monaco-vim",
+      "node_modules/@types"
+    ]
   },
   "include": [
     "src"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6254,6 +6254,11 @@ monaco-editor@^0.33.0:
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.33.0.tgz#842e244f3750a2482f8a29c676b5684e75ff34af"
   integrity sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw==
 
+monaco-vim@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/monaco-vim/-/monaco-vim-0.3.4.tgz#141d3e1129a563e63a7286a1472ccfe72b758abe"
+  integrity sha512-IVogmrQ6fRwW2PD9XRHFysOZBFj8qcRhgabu7GlGiNR14ApKMHz3pYOL1hDq1ctVPj1DS6hZd98vZrFxWr5d6A==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
* feat(103): add vim mode flag in state and settings

* feat(103): add vim mode option in settings

* feat(103): reorganize settings

* feat(103): fix default value for vim mode

* feat(103): add monaco-vim plugin

* feat(103): add vim state to root state

* feat(103): add monaco-vim typings

* feat(103): attach monaco-vim to the editor

* feat(103): display vim state in statusbar

* feat(vim): don't override private dispatch func

* feat(vim): set vim initial state

* feat(vim): fix vim and local storage sync

* feat(vim): fix vim and local storage sync

* feat(vim): fix vim command handle

* fix(vim): fix vim command handling and behavior

Co-authored-by: denys.sedchenko <denys.sedchenko@vestiairecollective.com>