### PR TITLE
Cache important API requests

### DIFF
--- a/web/src/service-worker.ts
+++ b/web/src/service-worker.ts
@@ -12,7 +12,7 @@ import { clientsClaim } from 'workbox-core';
 import { ExpirationPlugin } from 'workbox-expiration';
 import { precacheAndRoute, createHandlerBoundToURL } from 'workbox-precaching';
 import { registerRoute } from 'workbox-routing';
-import { StaleWhileRevalidate } from 'workbox-strategies';
+import {NetworkFirst, StaleWhileRevalidate} from 'workbox-strategies';
 
 declare const self: ServiceWorkerGlobalScope;
 
@@ -79,6 +79,23 @@ registerRoute(
     plugins: [
       new ExpirationPlugin({ maxAgeSeconds: 5 * DAY_IN_SECONDS }),
     ],
+  })
+)
+
+const apiEndpointsForCaching = new Set([
+  '/api/backends/info',
+  '/api/version'
+]);
+
+// Cache available Go versions from Go playground
+registerRoute(
+  ({url}) => (
+    url.origin === self.location.origin &&
+    apiEndpointsForCaching.has(url.pathname)
+  ),
+  new NetworkFirst({
+    cacheName: 'api',
+    networkTimeoutSeconds: 15,
   })
 )
 


### PR DESCRIPTION
This PR adds a few important API requests to ServiceWorker cache to provide descent experience in offline mode.

* `/api/version` - App version
* `/api/backends/info` - Go versions from Go playground
