### PR TITLE
Serve raw content length for static assets

### DIFF
--- a/internal/langserver/spa.go
+++ b/internal/langserver/spa.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -54,13 +55,15 @@ func (fs *SpaFileServer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	name := path.Join(dir, filepath.FromSlash(upath))
 
 	//check if file exists
-	if _, err := os.Stat(name); err != nil {
+	s, err := os.Stat(name)
+	if err != nil {
 		if os.IsNotExist(err) {
 			fs.NotFoundHandler.ServeHTTP(rw, r)
 			return
 		}
 	}
 
+	rw.Header().Set(rawContentLengthHeader, strconv.FormatInt(s.Size(), 10))
 	http.ServeFile(rw, r, name)
 }
 

--- a/web/src/services/gorepl/service.ts
+++ b/web/src/services/gorepl/service.ts
@@ -3,7 +3,8 @@ import {EvalEventKind} from "../api";
 import {ConsoleStreamType} from "~/lib/gowasm/bindings/stdio";
 import {
   newErrorAction,
-  newLoadingAction, newProgramFinishAction, newProgramStartAction,
+  newProgramFinishAction,
+  newProgramStartAction,
   newProgramWriteAction,
 } from "~/store/actions";
 import {DispatchFn, StateProvider} from "~/store/helpers";

--- a/web/src/store/dispatchers/settings.ts
+++ b/web/src/store/dispatchers/settings.ts
@@ -1,7 +1,7 @@
 import {isDarkModeEnabled} from "~/utils/theme";
 import config, {RunTargetConfig} from '~/services/config';
 
-import { Dispatcher, StateDispatch } from "./utils";
+import { Dispatcher } from "./utils";
 import {PanelState, SettingsState} from "../state";
 import { StateProvider, DispatchFn } from "../helpers";
 import {

--- a/web/src/store/reducers.ts
+++ b/web/src/store/reducers.ts
@@ -2,7 +2,7 @@ import { connectRouter } from 'connected-react-router';
 import { combineReducers } from 'redux';
 import {editor} from 'monaco-editor';
 
-import { RunResponse, EvalEvent } from '~/services/api';
+import { EvalEvent } from '~/services/api';
 import config, {
   MonacoSettings,
   RunTargetConfig


### PR DESCRIPTION
Serve `X-Raw-Content-Length` for static assets (Wasm binaries mainly) to provide proper progress reports on the UI side when content is served with compression.