### PR TITLE
fix: properly filter content length

### DIFF
--- a/internal/langserver/errors.go
+++ b/internal/langserver/errors.go
@@ -3,6 +3,15 @@ package langserver
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/x1unix/go-playground/pkg/goplay"
+)
+
+// ErrSnippetTooLarge is snippet max size limit error
+var ErrSnippetTooLarge = Errorf(
+	http.StatusRequestEntityTooLarge,
+	"code snippet too large (max %d bytes)",
+	goplay.MaxSnippetSize,
 )
 
 // HTTPError is HTTP response error

--- a/internal/langserver/middleware.go
+++ b/internal/langserver/middleware.go
@@ -2,7 +2,6 @@ package langserver
 
 import (
 	"errors"
-	"github.com/x1unix/go-playground/pkg/goplay"
 	"net/http"
 	"syscall"
 )
@@ -27,15 +26,6 @@ func WrapHandler(h HandlerFunc, guards ...GuardFn) http.HandlerFunc {
 
 		handleError(h(w, r), w)
 	}
-}
-
-// ValidateContentLength validates Go code snippet size
-func ValidateContentLength(r *http.Request) error {
-	if err := goplay.ValidateContentLength(int(r.ContentLength)); err != nil {
-		return NewHTTPError(http.StatusRequestEntityTooLarge, err)
-	}
-
-	return nil
 }
 
 func handleError(err error, w http.ResponseWriter) {

--- a/internal/langserver/request.go
+++ b/internal/langserver/request.go
@@ -3,7 +3,6 @@ package langserver
 import (
 	"encoding/json"
 	"go.uber.org/zap"
-	"io"
 	"net/http"
 	"strconv"
 )
@@ -59,14 +58,4 @@ func shouldFormatCode(r *http.Request) (bool, error) {
 	}
 
 	return boolVal, nil
-}
-
-func getPayloadFromRequest(r *http.Request) ([]byte, error) {
-	src, err := io.ReadAll(r.Body)
-	if err != nil {
-		return nil, Errorf(http.StatusBadGateway, "failed to read request: %s", err)
-	}
-
-	r.Body.Close()
-	return src, nil
 }

--- a/pkg/goplay/client.go
+++ b/pkg/goplay/client.go
@@ -17,13 +17,10 @@ const (
 	DefaultUserAgent     = "goplay.tools/1.0 (http://goplay.tools/)"
 	DefaultPlaygroundURL = "https://go.dev/_"
 
-	// maxSnippetSize value taken from
+	// MaxSnippetSize value taken from
 	// https://github.com/golang/playground/blob/master/app/goplay/share.go
-	maxSnippetSize = 64 * 1024
+	MaxSnippetSize = 64 * 1024
 )
-
-// ErrSnippetTooLarge is snippet max size limit error
-var ErrSnippetTooLarge = fmt.Errorf("code snippet too large (max %d bytes)", maxSnippetSize)
 
 // Client is Go Playground API client
 type Client struct {
@@ -89,12 +86,9 @@ func (c *Client) doRequest(ctx context.Context, method, url, contentType string,
 		return nil, NewHTTPError(response)
 	}
 
-	bodyBytes := &bytes.Buffer{}
-	_, err = io.Copy(bodyBytes, io.LimitReader(response.Body, maxSnippetSize+1))
+	bodyBytes := bytes.Buffer{}
+	_, err = io.Copy(&bodyBytes, response.Body)
 	if err != nil {
-		return nil, err
-	}
-	if err = ValidateContentLength(bodyBytes.Len()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/goplay/methods.go
+++ b/pkg/goplay/methods.go
@@ -8,14 +8,6 @@ import (
 	"net/url"
 )
 
-// ValidateContentLength validates snippet size
-func ValidateContentLength(itemLen int) error {
-	if itemLen > maxSnippetSize {
-		return ErrSnippetTooLarge
-	}
-	return nil
-}
-
 // GetSnippet returns snippet from Go playground
 func (c *Client) GetSnippet(ctx context.Context, snippetID string) (*Snippet, error) {
 	fileName := snippetID + ".go"

--- a/pkg/goplay/methods_test.go
+++ b/pkg/goplay/methods_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strconv"
 	"testing"
 	"time"
 
@@ -15,24 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/x1unix/go-playground/pkg/testutil"
 )
-
-func TestValidateContentLength(t *testing.T) {
-	cases := map[int]bool{
-		maxSnippetSize:      false,
-		maxSnippetSize + 10: true,
-		10:                  false,
-	}
-	for i, c := range cases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			err := ValidateContentLength(i)
-			if !c {
-				require.NoError(t, err)
-				return
-			}
-			require.Error(t, err)
-		})
-	}
-}
 
 func TestClient_Compile(t *testing.T) {
 	cases := map[string]struct {


### PR DESCRIPTION
Fixes false-positive "snippet too large" error and trims request body before reading