### PR TITLE
Use relative size for panel width

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,7 @@
     "file-saver": "^2.0.5",
     "monaco-editor": "^0.45.0",
     "monaco-vim": "^0.3.4",
-    "re-resizable": "^6.9.1",
+    "re-resizable": "^6.9.11",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^5.0.1",

--- a/web/public/examples/wasm/main.go
+++ b/web/public/examples/wasm/main.go
@@ -1,3 +1,5 @@
+//go:build js && wasm
+
 // This tutorial introduces Go WebAssembly features.
 //
 // Go code can be compiled and ran in web browser as WebAssembly module.

--- a/web/src/components/features/inspector/InspectorPanel/InspectorPanel.tsx
+++ b/web/src/components/features/inspector/InspectorPanel/InspectorPanel.tsx
@@ -16,46 +16,50 @@ const handleClasses = {
   left: 'InspectorPanel__handle--left',
 }
 
-export interface ResizePanelParams {
+export type SizeChanges = { height: number } | { width: number }
+
+export interface Props {
   layout?: LayoutType
   collapsed?: boolean
-  height?: string | number
-  width?: string | number
-}
-
-interface Props extends ResizePanelParams {
-  onViewChange?: (changes: ResizePanelParams) => void
+  heightPercent?: number
+  widthPercent?: number
+  onResize?: (size: SizeChanges) => void
+  onLayoutChange?: (layout: LayoutType) => void
+  onCollapsed?: (collapsed: boolean) => void
 }
 
 export const InspectorPanel: React.FC<Props> = ({
   layout = LayoutType.Vertical,
-  height = DEFAULT_PANEL_HEIGHT,
-  width = DEFAULT_PANEL_WIDTH,
+  heightPercent = DEFAULT_PANEL_HEIGHT,
+  widthPercent = DEFAULT_PANEL_WIDTH,
   collapsed,
-  onViewChange,
+  onResize,
+  onLayoutChange,
+  onCollapsed,
 }) => {
   const {
     palette: { accent },
     semanticColors: { buttonBorder },
   } = useTheme()
-  const onResize = useCallback(
-    (e, direction, ref, size) => {
+  const handleResize = useCallback(
+    (e, direction, ref) => {
+      const { offsetHeight, offsetWidth } = ref
       switch (layout) {
         case LayoutType.Vertical:
-          onViewChange?.({ height: height + size.height })
+          onResize?.({ height: offsetHeight })
           return
         case LayoutType.Horizontal:
-          onViewChange?.({ width: width + size.width })
+          onResize?.({ width: offsetWidth })
           break
         default:
       }
     },
-    [height, width, layout, onViewChange],
+    [layout, onResize],
   )
 
   const size = {
-    height: layout === LayoutType.Vertical ? height : '100%',
-    width: layout === LayoutType.Horizontal ? width : '100%',
+    height: layout === LayoutType.Vertical ? `${heightPercent}%` : '100%',
+    width: layout === LayoutType.Horizontal ? `${widthPercent}%` : '100%',
   }
 
   const enabledCorners = {
@@ -76,7 +80,7 @@ export const InspectorPanel: React.FC<Props> = ({
       handleClasses={handleClasses}
       size={size}
       enable={enabledCorners}
-      onResizeStop={onResize}
+      onResizeStop={handleResize}
       minHeight={MIN_HEIGHT}
       minWidth={MIN_WIDTH}
       style={
@@ -93,20 +97,20 @@ export const InspectorPanel: React.FC<Props> = ({
             hidden: layout === LayoutType.Vertical,
             icon: <VscSplitVertical />,
             label: 'Use vertical layout',
-            onClick: () => onViewChange?.({ layout: LayoutType.Vertical }),
+            onClick: () => onLayoutChange?.(LayoutType.Vertical),
           },
           'horizontal-layout': {
             desktopOnly: true,
             hidden: layout === LayoutType.Horizontal,
             icon: <VscSplitHorizontal />,
             label: 'Use horizontal layout',
-            onClick: () => onViewChange?.({ layout: LayoutType.Horizontal }),
+            onClick: () => onLayoutChange?.(LayoutType.Horizontal),
           },
           collapse: {
             hidden: layout === LayoutType.Horizontal,
             icon: collapsed ? <VscChevronUp /> : <VscChevronDown />,
             label: collapsed ? 'Expand' : 'Collapse',
-            onClick: () => onViewChange?.({ collapsed: !collapsed }),
+            onClick: () => onCollapsed?.(!collapsed),
           },
         }}
       />

--- a/web/src/components/features/inspector/InspectorPanel/InspectorPanel.tsx
+++ b/web/src/components/features/inspector/InspectorPanel/InspectorPanel.tsx
@@ -6,7 +6,7 @@ import { VscChevronDown, VscChevronUp, VscSplitHorizontal, VscSplitVertical } fr
 
 import { ConnectedRunOutput } from '../RunOutput'
 import { PanelHeader } from '~/components/elements/panel/PanelHeader'
-import { LayoutType, DEFAULT_PANEL_HEIGHT, DEFAULT_PANEL_WIDTH } from '~/styles/layout'
+import { LayoutType, DEFAULT_PANEL_HEIGHT, DEFAULT_PANEL_WIDTH_PERCENT } from '~/styles/layout'
 import './InspectorPanel.css'
 
 const MIN_HEIGHT = 36
@@ -19,19 +19,51 @@ const handleClasses = {
 export type SizeChanges = { height: number } | { width: number }
 
 export interface Props {
+  /**
+   * Panel layout
+   */
   layout?: LayoutType
+
+  /**
+   * Hide or show panel contents
+   */
   collapsed?: boolean
-  heightPercent?: number
+
+  /**
+   * Absolute height in pixels.
+   *
+   * Right now, resize in percent is buggy.
+   */
+  height?: number
+
+  /**
+   * Width in percents.
+   */
   widthPercent?: number
+
+  /**
+   * Resize handler
+   * @param size
+   */
   onResize?: (size: SizeChanges) => void
+
+  /**
+   * Panel orientation change handler.
+   * @param layout
+   */
   onLayoutChange?: (layout: LayoutType) => void
+
+  /**
+   * Panel collapse/expand handler.
+   * @param collapsed
+   */
   onCollapsed?: (collapsed: boolean) => void
 }
 
 export const InspectorPanel: React.FC<Props> = ({
   layout = LayoutType.Vertical,
-  heightPercent = DEFAULT_PANEL_HEIGHT,
-  widthPercent = DEFAULT_PANEL_WIDTH,
+  height = DEFAULT_PANEL_HEIGHT,
+  widthPercent = DEFAULT_PANEL_WIDTH_PERCENT,
   collapsed,
   onResize,
   onLayoutChange,
@@ -42,14 +74,14 @@ export const InspectorPanel: React.FC<Props> = ({
     semanticColors: { buttonBorder },
   } = useTheme()
   const handleResize = useCallback(
-    (e, direction, ref) => {
-      const { offsetHeight, offsetWidth } = ref
+    (e, direction, ref, delta) => {
+      const { height, width } = ref.getBoundingClientRect()
       switch (layout) {
         case LayoutType.Vertical:
-          onResize?.({ height: offsetHeight })
+          onResize?.({ height })
           return
         case LayoutType.Horizontal:
-          onResize?.({ width: offsetWidth })
+          onResize?.({ width })
           break
         default:
       }
@@ -58,7 +90,8 @@ export const InspectorPanel: React.FC<Props> = ({
   )
 
   const size = {
-    height: layout === LayoutType.Vertical ? `${heightPercent}%` : '100%',
+    // FIXME: Percent height flickers during resize. Use pixels for now.
+    height: layout === LayoutType.Vertical ? height : '100%',
     width: layout === LayoutType.Horizontal ? `${widthPercent}%` : '100%',
   }
 

--- a/web/src/components/features/inspector/InspectorPanel/index.ts
+++ b/web/src/components/features/inspector/InspectorPanel/index.ts
@@ -1,0 +1,1 @@
+export * from './InspectorPanel'

--- a/web/src/components/modals/AboutModal/AboutModal.tsx
+++ b/web/src/components/modals/AboutModal/AboutModal.tsx
@@ -18,7 +18,6 @@ import { getContentStyles, getIconButtonStyles } from '~/styles/modal'
 import environment from '~/environment'
 
 const TITLE_ID = 'AboutTitle'
-const SUB_TITLE_ID = 'AboutSubtitle'
 
 interface AboutModalProps {
   isOpen?: boolean
@@ -41,9 +40,12 @@ export const AboutModal: React.FC<AboutModalProps> = (props: AboutModalProps) =>
           maxWidth: '640px',
         },
         title: {
-          fontWeight: FontWeights.light,
+          fontWeight: FontWeights.semibold,
           fontSize: FontSizes.xxLargePlus,
-          padding: '1em 2em 2em 2em',
+          padding: '1em 0 2em',
+          color: 'transparent',
+          background:
+            'linear-gradient(to right, rgb(10,97,244) 0%, rgb(16, 187, 187) 100%) repeat scroll 0% 0% / auto padding-box text',
           textAlign: 'center',
         },
         info: {
@@ -65,14 +67,12 @@ export const AboutModal: React.FC<AboutModalProps> = (props: AboutModalProps) =>
   return (
     <Modal
       titleAriaId={TITLE_ID}
-      subtitleAriaId={SUB_TITLE_ID}
       isOpen={props.isOpen}
       onDismiss={props.onClose}
       styles={modalStyles}
       containerClassName={modalStyles.container}
     >
       <div className={contentStyles.header}>
-        <span id={TITLE_ID}>About</span>
         <IconButton
           iconProps={{ iconName: 'Cancel' }}
           styles={iconButtonStyles}
@@ -80,8 +80,10 @@ export const AboutModal: React.FC<AboutModalProps> = (props: AboutModalProps) =>
           onClick={props.onClose as any}
         />
       </div>
-      <div id={SUB_TITLE_ID} className={contentStyles.body}>
-        <div className={modalStyles.title}>Better Go Playground</div>
+      <div className={contentStyles.body}>
+        <div id={TITLE_ID} className={modalStyles.title}>
+          Better Go Playground
+        </div>
         <div className={modalStyles.info}>
           <Link href={environment.urls.github} target="_blank">
             <b>GitHub</b>

--- a/web/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/web/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -39,6 +39,11 @@ export const PlaygroundPage = connect(({ panel }: any) => ({ panelProps: panel }
             dispatch(dispatchPanelLayoutChange({ collapsed }))
           }}
           onResize={(changes) => {
+            if ('height' in changes) {
+              // Height percentage is buggy on resize. Use percents only for width.
+              dispatch(dispatchPanelLayoutChange(changes))
+              return
+            }
             const result = computeSizePercentage(changes, containerRef.current!)
             dispatch(dispatchPanelLayoutChange(result))
           }}

--- a/web/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/web/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { useParams } from 'react-router-dom'
 import { connect } from 'react-redux'
 
@@ -10,6 +10,7 @@ import { InspectorPanel } from '~/components/features/inspector/InspectorPanel/I
 import { NotificationHost } from '~/components/modals/Notification'
 import { Layout } from '~/components/layout/Layout/Layout'
 import { ConnectedStatusBar } from '~/components/layout/StatusBar'
+import { computeSizePercentage } from './utils'
 
 import styles from './PlaygroundPage.module.css'
 
@@ -18,20 +19,28 @@ interface PageParams {
 }
 
 export const PlaygroundPage = connect(({ panel }: any) => ({ panelProps: panel }))(({ panelProps, dispatch }: any) => {
+  const containerRef = useRef<HTMLDivElement>(null)
   const { snippetID } = useParams<PageParams>()
   useEffect(() => {
     dispatch(dispatchLoadSnippet(snippetID))
   }, [snippetID, dispatch])
 
   return (
-    <div className={styles.Playground}>
+    <div ref={containerRef} className={styles.Playground}>
       <Header />
       <Layout layout={panelProps.layout}>
         <ConnectedWorkspace />
         <InspectorPanel
           {...panelProps}
-          onViewChange={(changes) => {
-            dispatch(dispatchPanelLayoutChange(changes))
+          onLayoutChange={(layout) => {
+            dispatch(dispatchPanelLayoutChange({ layout }))
+          }}
+          onCollapsed={(collapsed) => {
+            dispatch(dispatchPanelLayoutChange({ collapsed }))
+          }}
+          onResize={(changes) => {
+            const result = computeSizePercentage(changes, containerRef.current!)
+            dispatch(dispatchPanelLayoutChange(result))
           }}
         />
         <NotificationHost />

--- a/web/src/components/pages/PlaygroundPage/utils.ts
+++ b/web/src/components/pages/PlaygroundPage/utils.ts
@@ -1,0 +1,22 @@
+import type { PanelState } from '~/store/state'
+import type { SizeChanges } from '~/components/features/inspector/InspectorPanel'
+
+type SizePercent = Pick<PanelState, 'heightPercent'> | Pick<PanelState, 'widthPercent'>
+type ContainerSize = Pick<HTMLElement, 'offsetHeight' | 'offsetWidth'>
+
+/**
+ * Convert absolute element size to percents based on parent element size
+ *
+ * @param elemSize Absolute child size
+ * @param offsetHeight Parent height
+ * @param offsetWidth Parent width
+ */
+export const computeSizePercentage = (
+  elemSize: SizeChanges,
+  { offsetHeight, offsetWidth }: ContainerSize,
+): SizePercent => {
+  const resultKey = 'height' in elemSize ? 'heightPercent' : 'widthPercent'
+  const absVal = 'height' in elemSize ? elemSize.height : elemSize.width
+  const totalVal = 'height' in elemSize ? offsetHeight : offsetWidth
+  return { [resultKey]: (absVal * 100) / totalVal }
+}

--- a/web/src/components/pages/PlaygroundPage/utils.ts
+++ b/web/src/components/pages/PlaygroundPage/utils.ts
@@ -1,7 +1,7 @@
 import type { PanelState } from '~/store/state'
 import type { SizeChanges } from '~/components/features/inspector/InspectorPanel'
 
-type SizePercent = Pick<PanelState, 'heightPercent'> | Pick<PanelState, 'widthPercent'>
+type SizePercent = Pick<PanelState, 'widthPercent'>
 type ContainerSize = Pick<HTMLElement, 'offsetHeight' | 'offsetWidth'>
 
 /**

--- a/web/src/store/state.ts
+++ b/web/src/store/state.ts
@@ -32,7 +32,7 @@ export interface SettingsState {
 }
 
 export interface PanelState {
-  heightPercent?: number
+  height?: number
   widthPercent?: number
   collapsed?: boolean
   layout?: LayoutType

--- a/web/src/store/state.ts
+++ b/web/src/store/state.ts
@@ -32,8 +32,8 @@ export interface SettingsState {
 }
 
 export interface PanelState {
-  height?: string | number
-  width?: string | number
+  heightPercent?: number
+  widthPercent?: number
   collapsed?: boolean
   layout?: LayoutType
 }

--- a/web/src/styles/layout.ts
+++ b/web/src/styles/layout.ts
@@ -1,14 +1,16 @@
+import type { PanelState } from '~/store/state'
+
 export enum LayoutType {
   Horizontal = 'horizontal',
   Vertical = 'vertical',
 }
 
-export const DEFAULT_PANEL_HEIGHT = 35
-export const DEFAULT_PANEL_WIDTH = 35
+export const DEFAULT_PANEL_HEIGHT = 300
+export const DEFAULT_PANEL_WIDTH_PERCENT = 35
 export const DEFAULT_PANEL_LAYOUT = LayoutType.Vertical
 
-export const defaultPanelProps = {
-  heightPercent: DEFAULT_PANEL_HEIGHT,
-  widthPercent: DEFAULT_PANEL_WIDTH,
+export const defaultPanelProps: PanelState = {
+  height: DEFAULT_PANEL_HEIGHT,
+  widthPercent: DEFAULT_PANEL_WIDTH_PERCENT,
   layout: DEFAULT_PANEL_LAYOUT,
 }

--- a/web/src/styles/layout.ts
+++ b/web/src/styles/layout.ts
@@ -3,12 +3,12 @@ export enum LayoutType {
   Vertical = 'vertical',
 }
 
-export const DEFAULT_PANEL_HEIGHT = 300
-export const DEFAULT_PANEL_WIDTH = 320
+export const DEFAULT_PANEL_HEIGHT = 35
+export const DEFAULT_PANEL_WIDTH = 35
 export const DEFAULT_PANEL_LAYOUT = LayoutType.Vertical
 
 export const defaultPanelProps = {
-  height: DEFAULT_PANEL_HEIGHT,
-  width: DEFAULT_PANEL_WIDTH,
+  heightPercent: DEFAULT_PANEL_HEIGHT,
+  widthPercent: DEFAULT_PANEL_WIDTH,
   layout: DEFAULT_PANEL_LAYOUT,
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4062,11 +4062,6 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-memoize@^2.5.1:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
-  integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
-
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
@@ -5647,12 +5642,10 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-re-resizable@^6.9.1:
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.1.tgz#6be082b55d02364ca4bfee139e04feebdf52441c"
-  integrity sha512-KRYAgr9/j1PJ3K+t+MBhlQ+qkkoLDJ1rs0z1heIWvYbCW/9Vq4djDU+QumJ3hQbwwtzXF6OInla6rOx6hhgRhQ==
-  dependencies:
-    fast-memoize "^2.5.1"
+re-resizable@^6.9.11:
+  version "6.9.11"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.11.tgz#f356e27877f12d926d076ab9ad9ff0b95912b475"
+  integrity sha512-a3hiLWck/NkmyLvGWUuvkAmN1VhwAz4yOhS6FdMTaxCUVN9joIWkT11wsO68coG/iEYuwn+p/7qAmfQzRhiPLQ==
 
 react-dom@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
Use relative size in percent for the output panel to keep the aspect ratio during window resizing.

Right now, it is implemented only for vertical layout due to flickering but on resize for horizontal layout.


https://github.com/x1unix/go-playground/assets/9203548/23b80b63-4677-4bfa-bef3-0019750f81e4

