### PR TITLE
feat: add file delete confirmation

### DIFF
--- a/web/src/components/elements/tabs/TabLabel/TabLabel.tsx
+++ b/web/src/components/elements/tabs/TabLabel/TabLabel.tsx
@@ -13,6 +13,9 @@ import {
 } from '@fluentui/react'
 import type { TabIconStyles } from '../types.ts'
 
+const BUTTON_PRIMARY = 0
+const BUTTON_WHEEL = 1
+
 const labelCellStyles: IStackStyles = {
   root: {
     flex: 1,
@@ -98,6 +101,18 @@ export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, on
 
   const iconStyle = active ? icon?.active : icon?.inactive
 
+  // onAuxClick doesn't work in Chrome, so only way to capture it is onMouseUp/Down.
+  const handleClick: React.MouseEventHandler = (e) => {
+    switch (e.button) {
+      case BUTTON_PRIMARY:
+        onClick?.()
+        break
+      case BUTTON_WHEEL:
+        onClose?.()
+        break
+    }
+  }
+
   const handleClose = useCallback(
     (e) => {
       e.stopPropagation()
@@ -114,7 +129,7 @@ export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, on
       horizontalAlign="stretch"
       verticalAlign="center"
       styles={containerStyles}
-      onClick={onClick}
+      onMouseUp={handleClick}
       title={label}
       aria-label={label}
       data-is-focusable

--- a/web/src/components/features/workspace/Workspace/Workspace.tsx
+++ b/web/src/components/features/workspace/Workspace/Workspace.tsx
@@ -17,6 +17,7 @@ import { FlexContainer } from '../FlexContainer'
 import { NewFileModal } from '../NewFileModal'
 import { ContentPlaceholder } from '../ContentPlaceholder'
 import { newEmptyFileContent } from './utils'
+import { useConfirmModal } from '~/components/modals/ConfirmModal'
 
 interface Props extends WorkspaceState {
   dispatch: StateDispatch
@@ -26,6 +27,7 @@ const Workspace: React.FC<Props> = ({ dispatch, files, selectedFile, snippet }) 
   const { palette, semanticColors } = useTheme()
   const uploadRef = useRef<HTMLInputElement>(null)
   const [modalOpen, setModalOpen] = useState(false)
+  const { showConfirm } = useConfirmModal()
 
   const tabIconStyles: TabIconStyles = {
     active: {
@@ -50,7 +52,15 @@ const Workspace: React.FC<Props> = ({ dispatch, files, selectedFile, snippet }) 
   )
 
   const onTabClose = (key: string) => {
-    dispatch(dispatchRemoveFile(key))
+    void showConfirm({
+      title: `Delete file "${key}"?`,
+      message: "This item will be deleted permanently. You can't undo this action.",
+      confirmText: 'Delete',
+    }).then((result) => {
+      if (result) {
+        dispatch(dispatchRemoveFile(key))
+      }
+    })
   }
 
   const onTabChange = (key: string) => {

--- a/web/src/components/modals/ConfirmModal/ConfirmContext.tsx
+++ b/web/src/components/modals/ConfirmModal/ConfirmContext.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useState, useContext } from 'react'
+import { ConfirmModal, type ConfirmProps } from './ConfirmModal'
+
+export type ConfirmArgs = Omit<ConfirmProps, 'isOpen' | 'onResult'>
+
+const ConfirmModalContext = createContext<{
+  showConfirm: (args: ConfirmArgs) => Promise<boolean>
+}>({
+  showConfirm: async () => {
+    throw new Error('ConfirmModalContext is not mounted')
+  },
+})
+
+export const useConfirmModal = () => useContext(ConfirmModalContext)
+
+const initialState: ConfirmProps = { isOpen: false, title: '', message: '' }
+
+interface ProviderProps {
+  children: React.ReactNode | React.ReactNode[]
+}
+
+export const ConfirmProvider = ({ children }: ProviderProps) => {
+  const [state, setState] = useState<ConfirmProps>(initialState)
+
+  const showConfirm = async (args: ConfirmArgs) => {
+    return await new Promise<boolean>((resolve) => {
+      const onResult = (result: boolean) => {
+        // Keep old title and message to avoid flicker during animation.
+        setState(args)
+        return resolve(result)
+      }
+
+      setState({ ...args, isOpen: true, onResult })
+    })
+  }
+
+  return (
+    <ConfirmModalContext.Provider value={{ showConfirm }}>
+      {children}
+      <ConfirmModal {...state} />
+    </ConfirmModalContext.Provider>
+  )
+}

--- a/web/src/components/modals/ConfirmModal/ConfirmModal.tsx
+++ b/web/src/components/modals/ConfirmModal/ConfirmModal.tsx
@@ -39,6 +39,7 @@ export const ConfirmModal: React.FC<ConfirmProps> = ({ isOpen, title, message, o
           />
           <PrimaryButton
             text={confirmText ?? 'OK'}
+            autoFocus={true}
             onClick={() => {
               onResult?.(true)
             }}

--- a/web/src/components/modals/ConfirmModal/ConfirmModal.tsx
+++ b/web/src/components/modals/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Stack, DefaultButton, PrimaryButton, DefaultSpacing, type IStackTokens } from '@fluentui/react'
+
+import { Dialog } from '~/components/elements/modals/Dialog'
+import { DialogActions } from '~/components/elements/modals/DialogActions'
+
+export interface ConfirmProps {
+  isOpen?: boolean
+  title: string
+  message: string
+  confirmText?: string
+  onResult?: (isConfirmed: boolean) => void
+}
+
+const modalStyles = {
+  main: {
+    maxWidth: 480,
+    minHeight: 'none',
+  },
+}
+
+const verticalStackTokens: IStackTokens = {
+  childrenGap: DefaultSpacing.s1,
+}
+
+export const ConfirmModal: React.FC<ConfirmProps> = ({ isOpen, title, message, onResult, confirmText }) => (
+  <Dialog label={title} isOpen={isOpen} styles={modalStyles} onDismiss={() => onResult?.(false)}>
+    <Stack tokens={verticalStackTokens}>
+      <Stack.Item>
+        <span>{message}</span>
+      </Stack.Item>
+      <Stack.Item>
+        <DialogActions>
+          <DefaultButton
+            text="Cancel"
+            onClick={() => {
+              onResult?.(false)
+            }}
+          />
+          <PrimaryButton
+            text={confirmText ?? 'OK'}
+            onClick={() => {
+              onResult?.(true)
+            }}
+          />
+        </DialogActions>
+      </Stack.Item>
+    </Stack>
+  </Dialog>
+)

--- a/web/src/components/modals/ConfirmModal/index.ts
+++ b/web/src/components/modals/ConfirmModal/index.ts
@@ -1,0 +1,1 @@
+export { type ConfirmArgs, ConfirmProvider, useConfirmModal } from './ConfirmContext'

--- a/web/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/web/src/components/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -13,6 +13,7 @@ import { ConnectedStatusBar } from '~/components/layout/StatusBar'
 import { computeSizePercentage } from './utils'
 
 import styles from './PlaygroundPage.module.css'
+import { ConfirmProvider } from '~/components/modals/ConfirmModal'
 
 interface PageParams {
   snippetID: string
@@ -29,26 +30,28 @@ export const PlaygroundPage = connect(({ panel }: any) => ({ panelProps: panel }
     <div ref={containerRef} className={styles.Playground}>
       <Header />
       <Layout layout={panelProps.layout}>
-        <ConnectedWorkspace />
-        <InspectorPanel
-          {...panelProps}
-          onLayoutChange={(layout) => {
-            dispatch(dispatchPanelLayoutChange({ layout }))
-          }}
-          onCollapsed={(collapsed) => {
-            dispatch(dispatchPanelLayoutChange({ collapsed }))
-          }}
-          onResize={(changes) => {
-            if ('height' in changes) {
-              // Height percentage is buggy on resize. Use percents only for width.
-              dispatch(dispatchPanelLayoutChange(changes))
-              return
-            }
-            const result = computeSizePercentage(changes, containerRef.current!)
-            dispatch(dispatchPanelLayoutChange(result))
-          }}
-        />
-        <NotificationHost />
+        <ConfirmProvider>
+          <ConnectedWorkspace />
+          <InspectorPanel
+            {...panelProps}
+            onLayoutChange={(layout) => {
+              dispatch(dispatchPanelLayoutChange({ layout }))
+            }}
+            onCollapsed={(collapsed) => {
+              dispatch(dispatchPanelLayoutChange({ collapsed }))
+            }}
+            onResize={(changes) => {
+              if ('height' in changes) {
+                // Height percentage is buggy on resize. Use percents only for width.
+                dispatch(dispatchPanelLayoutChange(changes))
+                return
+              }
+              const result = computeSizePercentage(changes, containerRef.current!)
+              dispatch(dispatchPanelLayoutChange(result))
+            }}
+          />
+          <NotificationHost />
+        </ConfirmProvider>
       </Layout>
       <ConnectedStatusBar />
     </div>


### PR DESCRIPTION
This PR adds file delete confirmation dialog.

In addition, adds mouse wheel click support to delete a file. 

![image](https://github.com/x1unix/go-playground/assets/9203548/b357a9e8-9fca-4fbf-9244-14bf3628b865)
