### PR TITLE
feat: support WebAssembly unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ export VITE_WASM_BASE_URL=/wasm
 
 .PHONY:run
 run:
-	@GOROOT=$(GOROOT) APP_CLEAN_INTERVAL=10h $(GO) run $(PKG) \
+	@GOROOT=$(GOROOT) APP_SKIP_MOD_CLEANUP=true $(GO) run $(PKG) \
 		-f ./data/packages.json \
 		-static-dir="$(UI)/build" \
 		-gtag-id="$(GTAG)" \

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -79,8 +79,10 @@ func start(goRoot string, logger *zap.Logger, cfg *config.Config) error {
 	buildSvc := builder.NewBuildService(zap.L(), buildCfg, store)
 
 	// Start cleanup service
-	cleanupSvc := builder.NewCleanupDispatchService(zap.L(), cfg.Build.CleanupInterval, buildSvc, store)
-	go cleanupSvc.Start(ctx)
+	if !cfg.Build.SkipModuleCleanup {
+		cleanupSvc := builder.NewCleanupDispatchService(zap.L(), cfg.Build.CleanupInterval, buildSvc, store)
+		go cleanupSvc.Start(ctx)
+	}
 
 	// Initialize API endpoints
 	r := mux.NewRouter()

--- a/internal/builder/check.go
+++ b/internal/builder/check.go
@@ -12,37 +12,77 @@ const (
 	maxFileCount = 12
 )
 
-func checkFileEntries(entries map[string][]byte) error {
+type projectType int
+
+const (
+	projectTypeProgram projectType = iota
+	projectTypeTest
+)
+
+type projectInfo struct {
+	projectType projectType
+}
+
+// checkFileEntries validates project file extensions and contents.
+//
+// In result returns project information such as whether this is a regular Go program or test.
+func checkFileEntries(entries map[string][]byte) (projectInfo, error) {
 	if len(entries) == 0 {
-		return newBuildError("no buildable Go source files")
+		return projectInfo{}, newBuildError("no buildable Go source files")
 	}
 
 	if len(entries) > maxFileCount {
-		return newBuildError("too many files (max: %d)", maxFileCount)
+		return projectInfo{}, newBuildError("too many files (max: %d)", maxFileCount)
+	}
+
+	info := projectInfo{
+		projectType: projectTypeProgram,
 	}
 
 	for name, contents := range entries {
-		if len(bytes.TrimSpace(contents)) == 0 {
-			return newBuildError("file %s is empty", name)
+		projType, err := checkFilePath(name)
+		if err != nil {
+			return info, err
 		}
 
-		if err := checkFilePath(name); err != nil {
-			return err
+		if len(bytes.TrimSpace(contents)) == 0 {
+			return projectInfo{}, newBuildError("file %s is empty", name)
+		}
+
+		if projType == projectTypeTest {
+			info.projectType = projType
 		}
 	}
 
-	return nil
+	return info, nil
 }
 
-func checkFilePath(fpath string) error {
+// checkFilePath check if file extension and path are correct.
+//
+// Also, if file is located at root, returns its Go file type - test or regular file.
+func checkFilePath(fpath string) (projectType, error) {
+	projType := projectTypeProgram
 	if err := goplay.ValidateFilePath(fpath, true); err != nil {
-		return newBuildError(err.Error())
+		return projType, newBuildError(err.Error())
 	}
 
 	pathDepth := strings.Count(fpath, "/")
 	if pathDepth > maxPathDepth {
-		return newBuildError("file path is too deep: %s", fpath)
+		return projType, newBuildError("file path is too deep: %s", fpath)
 	}
 
-	return nil
+	isRoot := false
+	switch pathDepth {
+	case 0:
+		isRoot = true
+	case 1:
+		// Path might be root but start with slash
+		isRoot = strings.HasPrefix(fpath, "/")
+	}
+
+	if isRoot && strings.HasSuffix(fpath, "_test.go") {
+		projType = projectTypeTest
+	}
+
+	return projType, nil
 }

--- a/internal/builder/check_test.go
+++ b/internal/builder/check_test.go
@@ -1,0 +1,118 @@
+package builder
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckFileEntries(t *testing.T) {
+	cases := map[string]struct {
+		input   map[string][]byte
+		inputFn func() map[string][]byte
+		expect  projectInfo
+		err     string
+	}{
+		"empty entries": {
+			input:  map[string][]byte{},
+			expect: projectInfo{},
+			err:    "no buildable Go source files",
+		},
+		"too many files": {
+			inputFn: func() map[string][]byte {
+				out := make(map[string][]byte)
+				for i := 0; i < maxFileCount+1; i++ {
+					key := fmt.Sprintf("file%d.go", i)
+					out[key] = []byte("package main")
+				}
+				return out
+			},
+			err: fmt.Sprintf("too many files (max: %d)", maxFileCount),
+		},
+		"invalid file name": {
+			input: map[string][]byte{
+				"": nil,
+			},
+			err: "file name cannot be empty",
+		},
+		"empty file content": {
+			input: map[string][]byte{
+				"main.go": nil,
+			},
+			err: "file main.go is empty",
+		},
+		"valid single program file": {
+			input: map[string][]byte{
+				"main.go": []byte("package main"),
+			},
+			expect: projectInfo{
+				projectType: projectTypeProgram,
+			},
+		},
+		"valid single test file": {
+			input: map[string][]byte{
+				"main_test.go": []byte("package main"),
+			},
+			expect: projectInfo{
+				projectType: projectTypeTest,
+			},
+		},
+		"valid program project with subpackage": {
+			input: map[string][]byte{
+				"pkg/foo_test.go": []byte("package main"),
+				"package.go":      []byte("package main"),
+			},
+			expect: projectInfo{
+				projectType: projectTypeProgram,
+			},
+		},
+		"valid test project with subpackage": {
+			input: map[string][]byte{
+				"pkg/main.go":  []byte("package main"),
+				"util_test.go": []byte("package main"),
+			},
+			expect: projectInfo{
+				projectType: projectTypeTest,
+			},
+		},
+		"valid multiple files with test file": {
+			input: map[string][]byte{
+				"main.go":      []byte("package main"),
+				"util_test.go": []byte("package main"),
+			},
+			expect: projectInfo{
+				projectType: projectTypeTest,
+			},
+		},
+		"file path too deep": {
+			err: fmt.Sprintf("file path is too deep: %smain.go", strings.Repeat("dir/", maxPathDepth+1)),
+			inputFn: func() map[string][]byte {
+				key := strings.Repeat("dir/", maxPathDepth+1)
+				key += "main.go"
+				return map[string][]byte{
+					key: []byte("package main"),
+				}
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			input := tc.input
+			if tc.inputFn != nil {
+				input = tc.inputFn()
+			}
+
+			result, err := checkFileEntries(input)
+			if tc.err != "" {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tc.err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expect, result)
+		})
+	}
+}

--- a/internal/server/handler_v1.go
+++ b/internal/server/handler_v1.go
@@ -354,7 +354,7 @@ func (s *APIv1Handler) HandleCompile(w http.ResponseWriter, r *http.Request) err
 		return err
 	}
 
-	resp := BuildResponse{FileName: result.FileName}
+	resp := BuildResponseV1{FileName: result.FileName}
 	if changed {
 		// Return formatted code if goimports had any effect
 		resp.Formatted = string(src)

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -32,6 +32,7 @@ func NewAPIv2Handler(client *goplay.Client, builder builder.BuildService) *APIv2
 	}
 }
 
+// HandleGetSnippet handles requests to get snippet by id.
 func (h *APIv2Handler) HandleGetSnippet(w http.ResponseWriter, r *http.Request) error {
 	vars := mux.Vars(r)
 	snippetID := vars["id"]
@@ -65,6 +66,7 @@ func (h *APIv2Handler) HandleGetSnippet(w http.ResponseWriter, r *http.Request) 
 	return nil
 }
 
+// HandleShare handles snippet share requests.
 func (h *APIv2Handler) HandleShare(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
@@ -90,6 +92,7 @@ func (h *APIv2Handler) HandleShare(w http.ResponseWriter, r *http.Request) error
 	return nil
 }
 
+// HandleFormat handles gofmt requests.
 func (h *APIv2Handler) HandleFormat(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
@@ -165,6 +168,7 @@ func (h *APIv2Handler) HandleRun(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
+// HandleCompile handles WebAssembly compile requests.
 func (h *APIv2Handler) HandleCompile(w http.ResponseWriter, r *http.Request) error {
 	// Limit for request timeout
 	ctx, cancel := context.WithDeadline(r.Context(), time.Now().Add(maxBuildTimeDuration))
@@ -188,8 +192,9 @@ func (h *APIv2Handler) HandleCompile(w http.ResponseWriter, r *http.Request) err
 		return err
 	}
 
-	WriteJSON(w, BuildResponse{
+	WriteJSON(w, BuildResponseV2{
 		FileName: result.FileName,
+		IsTest:   result.IsTest,
 	})
 	return nil
 }

--- a/internal/server/models.go
+++ b/internal/server/models.go
@@ -71,13 +71,22 @@ func (r SuggestionsResponse) Write(w http.ResponseWriter) {
 	WriteJSON(w, r)
 }
 
-// BuildResponse is code compile response
-type BuildResponse struct {
+// BuildResponseV1 is build response for legacy API.
+type BuildResponseV1 struct {
 	// Formatted contains goimport'ed code.
 	Formatted string `json:"formatted,omitempty"`
 
 	// FileName is file name
 	FileName string `json:"fileName,omitempty"`
+}
+
+// BuildResponseV2 is WASM build response for v2 api.
+type BuildResponseV2 struct {
+	// FileName is file name
+	FileName string `json:"fileName,omitempty"`
+
+	// IsUnitTest indicates whether payload is a Go test.
+	IsTest bool `json:"isTest"`
 }
 
 // RunResponse is code run response

--- a/pkg/testutil/matchers.go
+++ b/pkg/testutil/matchers.go
@@ -1,0 +1,46 @@
+package testutil
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type CmdMatcher struct {
+	cmd []string
+}
+
+// MatchCommand returns gomock matcher for exec.Cmd value.
+func MatchCommand(args ...string) CmdMatcher {
+	return CmdMatcher{
+		cmd: args,
+	}
+}
+
+func (m CmdMatcher) Matches(v any) bool {
+	cmd, ok := v.(*exec.Cmd)
+	if !ok {
+		return false
+	}
+
+	if len(cmd.Args) != len(m.cmd) {
+		return false
+	}
+
+	for i, v := range cmd.Args {
+		if i == 0 {
+			// exec.Cmd() resolves full binary path before execution.
+			// This may break tests.
+			v = filepath.Base(v)
+		}
+		if v != m.cmd[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (m CmdMatcher) String() string {
+	return strings.Join(m.cmd, " ")
+}

--- a/web/src/components/features/inspector/RunOutput/RunOutput.tsx
+++ b/web/src/components/features/inspector/RunOutput/RunOutput.tsx
@@ -16,10 +16,17 @@ interface StateProps {
   terminal: TerminalState
 }
 
+const linkStyle = {
+  root: {
+    // Fluent UI adds padding with :nth-child selector.
+    paddingLeft: '0 !important',
+  },
+}
+
 const highlightLinks = (str: string) =>
   splitStringUrls(str).map(({ isUrl, content }) =>
     isUrl ? (
-      <Link key={content} href={content} target="_blank" rel="noopener noreferrer nofollow">
+      <Link key={content} styles={linkStyle} href={content} target="_blank" rel="noopener noreferrer nofollow">
         {content}
       </Link>
     ) : (

--- a/web/src/services/api/models.ts
+++ b/web/src/services/api/models.ts
@@ -42,8 +42,8 @@ export interface FilesPayload {
 }
 
 export interface BuildResponse {
-  formatted?: string | null
   fileName: string
+  isTest: boolean
 }
 
 export interface VersionResponse {

--- a/web/src/services/config/monaco.ts
+++ b/web/src/services/config/monaco.ts
@@ -18,7 +18,7 @@ export const defaultMonacoSettings: MonacoSettings = {
   cursorBlinking: 'blink',
   cursorStyle: 'line',
   selectOnLineNumbers: true,
-  minimap: true,
+  minimap: false,
   contextMenu: true,
   smoothScrolling: true,
   mouseWheelZoom: true,

--- a/web/src/services/go/index.ts
+++ b/web/src/services/go/index.ts
@@ -14,13 +14,34 @@ interface LifecycleListener {
   onExit: (code: number) => void
 }
 
-export const goRun = async (m: WebAssembly.WebAssemblyInstantiatedSource) => {
+/**
+ * Runs Go WebAssembly binary.
+ *
+ * @param m WebAssembly instance.
+ * @param args Custom command line arguments.
+ */
+export const goRun = async (m: WebAssembly.WebAssemblyInstantiatedSource, args?: string[] | null) => {
   if (!instance) {
     throw new Error('Go runner instance is not initialized')
   }
 
   wrapper.reset()
-  await instance.run(m.instance as GoWebAssemblyInstance)
+  await instance.run(m.instance as GoWebAssemblyInstance, args)
+}
+
+/**
+ * Runs Go unit test WebAssembly binary with testing arguments (`-test.v`).
+ *
+ * @param m WebAssembly instance.
+ * @param args Additional command line arguments.
+ */
+export const goTestRun = async (m: WebAssembly.WebAssemblyInstantiatedSource, args?: string[] | null) => {
+  let testArgs = ['-test.v']
+  if (args?.length) {
+    testArgs = testArgs.concat(args)
+  }
+
+  return await goRun(m, testArgs)
 }
 
 export const getImportObject = () => instance.importObject

--- a/web/src/store/dispatchers/build.ts
+++ b/web/src/store/dispatchers/build.ts
@@ -1,5 +1,5 @@
 import { TargetType } from '~/services/config'
-import { getImportObject, goRun } from '~/services/go'
+import { getImportObject, goRun, goTestRun } from '~/services/go'
 import { setTimeoutNanos, SECOND } from '~/utils/duration'
 import { instantiateStreaming } from '~/lib/go'
 import client, { type EvalEvent, EvalEventKind } from '~/services/api'
@@ -200,13 +200,14 @@ export const runFileDispatcher: Dispatcher = async (dispatch: DispatchFn, getSta
         break
       }
       case TargetType.WebAssembly: {
-        const { fileName } = await client.build(files)
+        const { fileName, isTest } = await client.build(files)
 
         const instance = await fetchWasmWithProgress(dispatch, fileName)
         dispatch(newRemoveNotificationAction(NotificationIDs.WASMAppDownload))
         dispatch(newProgramStartAction())
 
-        goRun(instance)
+        const runFunc = isTest ? goTestRun : goRun
+        runFunc(instance)
           .then((result) => {
             console.log('exit code: %d', result)
           })


### PR DESCRIPTION
This PR adds support of Go unit tests compilation.

In order to compile project as unit test, file should nave a `_test.go` prefix (like in regular Go).

In addition, this PR fixes deterministic hash keys for WASM entries.

![image](https://github.com/x1unix/go-playground/assets/9203548/f5ffddda-a127-4b41-a07f-647fa536f51a)
