### PR TITLE
feat(wasm): add benchmark support

### DIFF
--- a/internal/builder/compiler_test.go
+++ b/internal/builder/compiler_test.go
@@ -300,6 +300,45 @@ func TestBuildService_Build(t *testing.T) {
 				}
 			},
 		},
+		"benchmark and fuzzing": {
+			files: map[string][]byte{
+				"bench_test.go": []byte("package main\nfunc BenchmarkFoo(b *testing.B) {\n}"),
+				"fuzz_test.go":  []byte("package main\nfunc FuzzFoo(b *testing.F) {\n}"),
+				"go.mod":        []byte("module foo"),
+			},
+			store: func(t *testing.T, _ map[string][]byte) (storage.StoreProvider, func() error) {
+				return testStorage{
+					hasItem: func(id storage.ArtifactID) (bool, error) {
+						return false, nil
+					},
+					createWorkspace: func(id storage.ArtifactID, entries map[string][]byte) (*storage.Workspace, error) {
+						return &storage.Workspace{
+							WorkDir:    "/tmp",
+							BinaryPath: "test.wasm",
+							Files:      nil,
+						}, nil
+					},
+					clean: func(_ context.Context) error {
+						t.Log("cleanup called")
+						return nil
+					},
+				}, nil
+			},
+			cmdRunner: func(t *testing.T, ctrl *gomock.Controller) CommandRunner {
+				m := NewMockCommandRunner(ctrl)
+				m.EXPECT().RunCommand(testutil.MatchCommand("go", "mod", "tidy")).Return(nil)
+				m.EXPECT().RunCommand(testutil.MatchCommand("go", "test", "-bench=.", "-fuzz=.", "-c", "-o", "test.wasm")).Return(nil)
+				return m
+			},
+			wantResult: func(files map[string][]byte) *Result {
+				return &Result{
+					FileName:     mustArtifactID(t, files).String() + ".wasm",
+					IsTest:       true,
+					HasBenchmark: true,
+					HasFuzz:      true,
+				}
+			},
+		},
 	}
 
 	for n, c := range cases {

--- a/internal/builder/detect_test.go
+++ b/internal/builder/detect_test.go
@@ -86,6 +86,17 @@ func TestCheckFileEntries(t *testing.T) {
 				projectType: projectTypeTest,
 			},
 		},
+		"detect fuzz and bench": {
+			input: map[string][]byte{
+				"bench_test.go": []byte("package main\nfunc BenchmarkFoo(b *testing.B) {\n}"),
+				"fuzz_test.go":  []byte("package main\nfunc FuzzFoo(b *testing.F) {\n}"),
+			},
+			expect: projectInfo{
+				projectType:  projectTypeTest,
+				hasBenchmark: true,
+				hasFuzz:      true,
+			},
+		},
 		"file path too deep": {
 			err: fmt.Sprintf("file path is too deep: %smain.go", strings.Repeat("dir/", maxPathDepth+1)),
 			inputFn: func() map[string][]byte {
@@ -105,7 +116,7 @@ func TestCheckFileEntries(t *testing.T) {
 				input = tc.inputFn()
 			}
 
-			result, err := checkFileEntries(input)
+			result, err := detectProjectType(input)
 			if tc.err != "" {
 				assert.Error(t, err)
 				assert.EqualError(t, err, tc.err)

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/time/rate"
 	"net/http"
 	"time"
+
+	"golang.org/x/time/rate"
 
 	"github.com/gorilla/mux"
 	"github.com/x1unix/go-playground/internal/builder"
@@ -193,8 +194,10 @@ func (h *APIv2Handler) HandleCompile(w http.ResponseWriter, r *http.Request) err
 	}
 
 	WriteJSON(w, BuildResponseV2{
-		FileName: result.FileName,
-		IsTest:   result.IsTest,
+		FileName:     result.FileName,
+		IsTest:       result.IsTest,
+		HasBenchmark: result.HasBenchmark,
+		HasFuzz:      result.HasFuzz,
 	})
 	return nil
 }

--- a/internal/server/models.go
+++ b/internal/server/models.go
@@ -86,13 +86,13 @@ type BuildResponseV2 struct {
 	FileName string `json:"fileName,omitempty"`
 
 	// IsUnitTest indicates whether payload is a Go test.
-	IsTest bool `json:"isTest"`
+	IsTest bool `json:"isTest,omitempty"`
 
 	// HasBenchmark indicates whether program contains a benchmark.
-	HasBenchmark bool `json:"hasBenchmark"`
+	HasBenchmark bool `json:"hasBenchmark,omitempty"`
 
 	// HasFuzz indicates whether program contains a fuzz test inside.
-	HasFuzz bool `json:"hasFuzz`
+	HasFuzz bool `json:"hasFuzz,omitempty"`
 }
 
 // RunResponse is code run response

--- a/internal/server/models.go
+++ b/internal/server/models.go
@@ -87,6 +87,12 @@ type BuildResponseV2 struct {
 
 	// IsUnitTest indicates whether payload is a Go test.
 	IsTest bool `json:"isTest"`
+
+	// HasBenchmark indicates whether program contains a benchmark.
+	HasBenchmark bool `json:"hasBenchmark"`
+
+	// HasFuzz indicates whether program contains a fuzz test inside.
+	HasFuzz bool `json:"hasFuzz`
 }
 
 // RunResponse is code run response

--- a/web/src/services/api/models.ts
+++ b/web/src/services/api/models.ts
@@ -43,7 +43,9 @@ export interface FilesPayload {
 
 export interface BuildResponse {
   fileName: string
-  isTest: boolean
+  isTest?: boolean
+  hasBenchmark?: boolean
+  hasFuzz?: boolean
 }
 
 export interface VersionResponse {

--- a/web/src/services/go/index.ts
+++ b/web/src/services/go/index.ts
@@ -29,21 +29,6 @@ export const goRun = async (m: WebAssembly.WebAssemblyInstantiatedSource, args?:
   await instance.run(m.instance as GoWebAssemblyInstance, args)
 }
 
-/**
- * Runs Go unit test WebAssembly binary with testing arguments (`-test.v`).
- *
- * @param m WebAssembly instance.
- * @param args Additional command line arguments.
- */
-export const goTestRun = async (m: WebAssembly.WebAssemblyInstantiatedSource, args?: string[] | null) => {
-  let testArgs = ['-test.v']
-  if (args?.length) {
-    testArgs = testArgs.concat(args)
-  }
-
-  return await goRun(m, testArgs)
-}
-
 export const getImportObject = () => instance.importObject
 
 export const bootstrapGo = (logger: ConsoleLogger, listener: LifecycleListener) => {


### PR DESCRIPTION
Pass benchmark (`-test.bench`) and fuzzing (`-test.fuzz`) flags to WASM binary.

![image](https://github.com/user-attachments/assets/459fa3e5-b3fe-402b-8364-595eb8eee1b4)
