### PR TITLE
fix: fix double-click issue on touch devices

### DIFF
--- a/web/src/components/elements/tabs/TabHeader/TabHeader.tsx
+++ b/web/src/components/elements/tabs/TabHeader/TabHeader.tsx
@@ -54,6 +54,7 @@ export const TabHeader: React.FC<Props> = ({
     }
   }, [semanticColors])
 
+  const isTouchDevice = navigator.maxTouchPoints > 0
   const cmdToolbarStyles: IStackStyles = {
     root: {
       display: 'flex',
@@ -61,7 +62,7 @@ export const TabHeader: React.FC<Props> = ({
   }
 
   return (
-    <FocusZone style={{ flex: 1 }}>
+    <FocusZone disabled={isTouchDevice} style={{ flex: 1 }}>
       <Stack
         grow
         horizontal

--- a/web/src/components/elements/tabs/TabLabel/TabLabel.tsx
+++ b/web/src/components/elements/tabs/TabLabel/TabLabel.tsx
@@ -103,7 +103,7 @@ export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, on
   const iconStyle = active ? icon?.active : icon?.inactive
 
   // onAuxClick doesn't work in Chrome, so only way to capture it is onMouseUp/Down.
-  const handleClick: React.MouseEventHandler = (e) => {
+  const handleClick: React.MouseEventHandler<HTMLElement> = (e) => {
     switch (e.button) {
       case BUTTON_PRIMARY:
         onClick?.()
@@ -114,11 +114,7 @@ export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, on
     }
   }
 
-  const handleTouch: React.TouchEventHandler = (e) => {
-    onClick?.()
-  }
-
-  const handleClose = useCallback(
+  const handleClose: React.MouseEventHandler<HTMLElement> = useCallback(
     (e) => {
       e.stopPropagation()
       onClose?.()
@@ -135,7 +131,6 @@ export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, on
       verticalAlign="center"
       styles={containerStyles}
       onMouseUp={handleClick}
-      onTouchEnd={handleTouch}
       title={label}
       aria-label={label}
       data-is-focusable
@@ -162,11 +157,7 @@ export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, on
             disabled={disabled}
             iconProps={{ iconName: 'Cancel' }}
             styles={btnStyles}
-            onClick={handleClose}
-            onTouchEnd={(e) => {
-              e.stopPropagation()
-              onClose?.()
-            }}
+            onMouseUp={handleClose}
           />
         </Stack.Item>
       ) : null}

--- a/web/src/components/elements/tabs/TabLabel/TabLabel.tsx
+++ b/web/src/components/elements/tabs/TabLabel/TabLabel.tsx
@@ -36,6 +36,7 @@ interface Props {
 
 export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, onClose, canClose, icon }) => {
   const theme = useTheme()
+  const isTouchDevice = navigator.maxTouchPoints > 0
 
   const containerStyles: IStackStyles = useMemo(() => {
     const { palette, semanticColors } = theme
@@ -84,7 +85,7 @@ export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, on
         lineHeight: 'auto',
         fontSize: FontSizes.smallPlus,
         color: 'inherit',
-        opacity: active ? '1' : '0',
+        opacity: isTouchDevice || active ? '1' : '0',
         ':focus': {
           opacity: '1',
         },
@@ -97,7 +98,7 @@ export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, on
         color: 'inherit',
       },
     }
-  }, [active])
+  }, [active, isTouchDevice])
 
   const iconStyle = active ? icon?.active : icon?.inactive
 
@@ -111,6 +112,10 @@ export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, on
         onClose?.()
         break
     }
+  }
+
+  const handleTouch: React.TouchEventHandler = (e) => {
+    onClick?.()
   }
 
   const handleClose = useCallback(
@@ -130,6 +135,7 @@ export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, on
       verticalAlign="center"
       styles={containerStyles}
       onMouseUp={handleClick}
+      onTouchEnd={handleTouch}
       title={label}
       aria-label={label}
       data-is-focusable
@@ -157,6 +163,10 @@ export const TabLabel: React.FC<Props> = ({ label, active, disabled, onClick, on
             iconProps={{ iconName: 'Cancel' }}
             styles={btnStyles}
             onClick={handleClose}
+            onTouchEnd={(e) => {
+              e.stopPropagation()
+              onClose?.()
+            }}
           />
         </Stack.Item>
       ) : null}


### PR DESCRIPTION
Fix file tabs navigation issues on touch devices (iPad, phones). Previously tabs switch or close required double tap due to FocusZone trap intercepting any events.

This PR fixes this issue and also makes close button appear always for touch devices as middle click is not available for them. 


https://github.com/user-attachments/assets/7a67f06e-2de2-4e78-a8f3-aa3bb4a20644

