### PR TITLE
fix: adjust HTTP response timeout

### DIFF
--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -119,9 +119,9 @@ func start(goRoot string, logger *zap.Logger, cfg *config.Config) error {
 	srv := &http.Server{
 		Addr:         cfg.HTTP.Addr,
 		Handler:      r,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		IdleTimeout:  15 * time.Second,
+		ReadTimeout:  cfg.HTTP.ReadTimeout,
+		WriteTimeout: cfg.HTTP.WriteTimeout,
+		IdleTimeout:  cfg.HTTP.IdleTimeout,
 	}
 
 	if err := startHttpServer(ctx, wg, srv); err != nil {

--- a/docs/deployment/docker/README.md
+++ b/docs/deployment/docker/README.md
@@ -24,6 +24,8 @@ Playground server can be configured using environment variables described below.
 |------------------------|--------------------------------|----------------------------------------------------------------|
 | `GOROOT`               | `/usr/local/go`                | Go root location. Uses `go env GOROOT` as fallback.            |
 | `APP_DEBUG`            | `false`                        | Enables debug logging.                                         |
+| `APP_LOG_LEVEL`        | `info`                         | Logger log level. `debug` requires `APP_DEBUG` env var.        |
+| `APP_LOG_FORMAT`       | `console`, `json`              | Log format                                                     | 
 | `APP_PLAYGROUND_URL`   | `https://play.golang.org`      | Official Go playground service URL.                            |
 | `APP_GOTIP_URL`        | `https://gotipplay.golang.org` | GoTip playground service URL.                                  |
 | `APP_BUILD_DIR`        | `/var/cache/wasm`              | Path to store cached WebAssembly builds.                       |
@@ -45,13 +47,13 @@ make docker [...params]
 ### Required params
 
 | Parameter     | Description                |
-| ------------- | -------------------------- |
+|---------------|----------------------------|
 | `TAG`         | Image tag (version)        |
 | `DOCKER_USER` | Docker repository user     |
 | `DOCKER_PASS` | Docker repository password |
 
 ### Optional params
 
-| Parameter     | Defaults               | Description                |
-| ------------- | ---------------------- | -------------------------- |
-| `IMG_NAME`    | `x1unix/go-playground` | Image tag (version)        |
+| Parameter  | Defaults               | Description         |
+|------------|------------------------|---------------------|
+| `IMG_NAME` | `x1unix/go-playground` | Image tag (version) |

--- a/docs/deployment/docker/README.md
+++ b/docs/deployment/docker/README.md
@@ -21,7 +21,7 @@ docker-compose ps
 Playground server can be configured using environment variables described below.
 
 | Environment Variable   | Example                        | Description                                                    |
-| ---------------------- | ------------------------------ | -------------------------------------------------------------- |
+|------------------------|--------------------------------|----------------------------------------------------------------|
 | `GOROOT`               | `/usr/local/go`                | Go root location. Uses `go env GOROOT` as fallback.            |
 | `APP_DEBUG`            | `false`                        | Enables debug logging.                                         |
 | `APP_PLAYGROUND_URL`   | `https://play.golang.org`      | Official Go playground service URL.                            |
@@ -30,6 +30,9 @@ Playground server can be configured using environment variables described below.
 | `APP_CLEAN_INTERVAL`   | `10m`                          | WebAssembly build files cache cleanup interval.                |
 | `APP_SKIP_MOD_CLEANUP` | `1`                            | Disables WASM builds cache cleanup.                            |
 | `APP_PERMIT_ENV_VARS`  | `GOSUMDB,GOPROXY`              | Restricts list of environment variables passed to Go compiler. |
+| `HTTP_READ_TIMEOUT`    | `15s`                          | HTTP request read timeout.                                     |
+| `HTTP_WRITE_TIMEOUT`   | `60s`                          | HTTP response timeout.                                         |
+| `HTTP_IDLE_TIMEOUT`    | `90s`                          | HTTP keep alive timeout.                                       |
 
 ## Building custom image
 

--- a/docs/deployment/gcloud/README.md
+++ b/docs/deployment/gcloud/README.md
@@ -13,3 +13,7 @@
 * Prepare Terraform plan using variables file: \
     `terraform plan -var-file="prod.tfvars" -out=tfplan`
 * Apply a plan using `terraform apply tfplan` command.
+
+## Configuration
+
+See environment variables section in [Docker](../docker/README.md) docs.

--- a/docs/deployment/systemd/README.md
+++ b/docs/deployment/systemd/README.md
@@ -34,3 +34,7 @@ Check if service is running:
 ```shell
 systemctl status better-go-playground.service
 ```
+
+## Configuration
+
+See environment variables section in [Docker](../docker/README.md) docs.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,12 +12,27 @@ import (
 	"github.com/x1unix/go-playground/pkg/util/cmdutil"
 )
 
+const (
+	DefaultWriteTimeout = 60 * time.Second
+	DefaultReadTimeout  = 15 * time.Second
+	DefaultIdleTimeout  = 90 * time.Second
+)
+
 type HTTPConfig struct {
 	// Addr is HTTP server listen address
 	Addr string `envconfig:"APP_HTTP_ADDR" json:"addr"`
 
 	// AssetsDir is directory which contains frontend assets
 	AssetsDir string `envconfig:"APP_ASSETS_DIR" json:"assetsDir"`
+
+	// WriteTimeout is HTTP response write timeout.
+	WriteTimeout time.Duration `envconfig:"HTTP_WRITE_TIMEOUT"`
+
+	// ReadTimeout is HTTP request read timeout.
+	ReadTimeout time.Duration `envconfig:"HTTP_READ_TIMEOUT"`
+
+	// IdleTimeout is delay timeout between requests to keep connection alive.
+	IdleTimeout time.Duration `envconfig:"HTTP_IDLE_TIMEOUT"`
 }
 
 func (cfg *HTTPConfig) mountFlagSet(f *flag.FlagSet) {
@@ -28,6 +43,9 @@ func (cfg *HTTPConfig) mountFlagSet(f *flag.FlagSet) {
 
 	f.StringVar(&cfg.Addr, "addr", ":8080", "TCP Listen address")
 	f.StringVar(&cfg.AssetsDir, "static-dir", filepath.Join(wd, "public"), "Path to web page assets (HTML, JS, etc)")
+	f.DurationVar(&cfg.WriteTimeout, "http-write-timeout", DefaultWriteTimeout, "HTTP response write timeout")
+	f.DurationVar(&cfg.ReadTimeout, "http-read-timeout", DefaultReadTimeout, "HTTP request read timeout")
+	f.DurationVar(&cfg.IdleTimeout, "http-idle-timeout", DefaultIdleTimeout, "HTTP keep alive timeout")
 }
 
 type PlaygroundConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,8 +12,11 @@ import (
 func TestFromFlags(t *testing.T) {
 	expect := Config{
 		HTTP: HTTPConfig{
-			Addr:      "testaddr",
-			AssetsDir: "testdir",
+			Addr:         "testaddr",
+			AssetsDir:    "testdir",
+			ReadTimeout:  7 * time.Second,
+			WriteTimeout: 6 * time.Second,
+			IdleTimeout:  3 * time.Second,
 		},
 		Playground: PlaygroundConfig{
 			PlaygroundURL:  "pgurl",
@@ -54,6 +57,9 @@ func TestFromFlags(t *testing.T) {
 		"-sentry-dsn=testdsn",
 		"-sentry-breadcrumbs=1",
 		"-skip-mod-clean",
+		"-http-read-timeout=7s",
+		"-http-write-timeout=6s",
+		"-http-idle-timeout=3s",
 	}
 
 	fl := flag.NewFlagSet("app", flag.PanicOnError)
@@ -96,8 +102,11 @@ func TestFromEnv(t *testing.T) {
 		"process environment variables": {
 			expect: Config{
 				HTTP: HTTPConfig{
-					Addr:      "testaddr",
-					AssetsDir: "testdir",
+					Addr:         "testaddr",
+					AssetsDir:    "testdir",
+					ReadTimeout:  21 * time.Second,
+					WriteTimeout: 22 * time.Second,
+					IdleTimeout:  23 * time.Second,
 				},
 				Playground: PlaygroundConfig{
 					PlaygroundURL:  "pgurl",
@@ -139,6 +148,9 @@ func TestFromEnv(t *testing.T) {
 				"SENTRY_DSN":              "testdsn",
 				"SENTRY_USE_BREADCRUMBS":  "1",
 				"SENTRY_BREADCRUMB_LEVEL": "debug",
+				"HTTP_READ_TIMEOUT":       "21s",
+				"HTTP_WRITE_TIMEOUT":      "22s",
+				"HTTP_IDLE_TIMEOUT":       "23s",
 			},
 		},
 	}


### PR DESCRIPTION
This PR bumps default HTTP read and write timeouts + makes them configurable.

This PR address recent often 502 errors caused by slow upstream response.