### PR TITLE
fix: use persistent default go module name

### DIFF
--- a/internal/builder/compiler.go
+++ b/internal/builder/compiler.go
@@ -87,6 +87,11 @@ func (s BuildService) Build(ctx context.Context, files map[string][]byte) (*Resu
 		return nil, err
 	}
 
+	// Go module is required to build project
+	if _, ok := files["go.mod"]; !ok {
+		files["go.mod"] = generateGoMod(defaultGoModName)
+	}
+
 	aid, err := storage.GetArtifactID(files)
 	if err != nil {
 		return nil, err
@@ -109,11 +114,6 @@ func (s BuildService) Build(ctx context.Context, files map[string][]byte) (*Resu
 		// Just return precompiled result if data is cached already
 		s.log.Debug("build cached, returning cached file", zap.Stringer("artifact", aid))
 		return result, nil
-	}
-
-	// Go module is required to build project
-	if _, ok := files["go.mod"]; !ok {
-		files["go.mod"] = generateGoMod(defaultGoModName)
 	}
 
 	workspace, err := s.storage.CreateWorkspace(aid, files)

--- a/internal/builder/compiler.go
+++ b/internal/builder/compiler.go
@@ -14,6 +14,9 @@ import (
 	"go.uber.org/zap"
 )
 
+// defaultGoModName is default module name that will be set if no go.mod provided.
+const defaultGoModName = "app"
+
 // predefinedBuildVars is list of environment vars which contain build values
 var predefinedBuildVars = osutil.EnvironmentVariables{
 	"CGO_ENABLED": "0",
@@ -110,7 +113,7 @@ func (s BuildService) Build(ctx context.Context, files map[string][]byte) (*Resu
 
 	// Go module is required to build project
 	if _, ok := files["go.mod"]; !ok {
-		files["go.mod"] = generateGoMod(aid.String())
+		files["go.mod"] = generateGoMod(defaultGoModName)
 	}
 
 	workspace, err := s.storage.CreateWorkspace(aid, files)


### PR DESCRIPTION
Use standard Go module name if `go.mod` isn't provided for consistent hash keys.