### PR TITLE
feat: Refactor settings and make autosave optional

### DIFF
--- a/web/src/components/elements/misc/Kbd/Kbd.tsx
+++ b/web/src/components/elements/misc/Kbd/Kbd.tsx
@@ -1,0 +1,14 @@
+import { mergeStyles, useTheme } from '@fluentui/react'
+import React from 'react'
+
+export const Kbd: React.FC = ({ children }) => {
+  const { semanticColors } = useTheme()
+
+  const style = mergeStyles({
+    padding: '1px 3px',
+    borderRadius: '4px',
+    background: semanticColors.disabledSubtext,
+  })
+
+  return <kbd className={style}>{children}</kbd>
+}

--- a/web/src/components/elements/misc/Kbd/index.ts
+++ b/web/src/components/elements/misc/Kbd/index.ts
@@ -1,0 +1,1 @@
+export * from './Kbd'

--- a/web/src/components/features/settings/SettingsModal.tsx
+++ b/web/src/components/features/settings/SettingsModal.tsx
@@ -247,7 +247,7 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
               title="Mouse Wheel Zoom"
               control={
                 <Checkbox
-                  label="Zoom the font in the editor when using the mouse wheel in combination with holding Ctrl"
+                  label="Zoom the font in the editor when using the mouse wheel in combination with holding Ctrl / ⌘ key"
                   defaultChecked={this.props.monaco?.mouseWheelZoom}
                   onChange={(_, val) => {
                     this.touchMonacoProperty('mouseWheelZoom', val)

--- a/web/src/components/features/settings/SettingsModal.tsx
+++ b/web/src/components/features/settings/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Checkbox, Dropdown, type IPivotStyles, PivotItem, TextField } from '@fluentui/react'
+import { Checkbox, Dropdown, getTheme, type IPivotStyles, PivotItem, Text, TextField } from '@fluentui/react'
 
 import { AnimatedPivot } from '~/components/elements/tabs/AnimatedPivot'
 import { ThemeableComponent } from '~/components/utils/ThemeableComponent'
@@ -11,6 +11,8 @@ import type { RenderingBackend, TerminalSettings } from '~/store/terminal'
 import { connect, type StateDispatch, type MonacoParamsChanges, type SettingsState } from '~/store'
 
 import { cursorBlinkOptions, cursorLineOptions, fontOptions, terminalBackendOptions } from './options'
+import { controlKeyLabel } from '~/utils/dom'
+import { Kbd } from '~/components/elements/misc/Kbd'
 
 export interface SettingsChanges {
   monaco?: MonacoParamsChanges
@@ -40,7 +42,7 @@ interface SettingsModalState {
 
 const modalStyles = {
   main: {
-    maxWidth: 480,
+    maxWidth: 520,
   },
 }
 
@@ -100,6 +102,7 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
 
   render() {
     const { isOpen } = this.props
+    const { spacing } = getTheme()
 
     return (
       <Dialog label="Settings" onDismiss={() => this.onClose()} isOpen={isOpen} styles={modalStyles}>
@@ -165,8 +168,12 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
               title="Mouse Wheel Zoom"
               control={
                 <Checkbox
-                  label="Zoom the font in the editor when using the mouse wheel in combination with holding Ctrl / ⌘ key"
                   defaultChecked={this.props.monaco?.mouseWheelZoom}
+                  onRenderLabel={() => (
+                    <Text className="ms-Checkbox-text" style={{ marginLeft: spacing.s2 }}>
+                      Zoom the editor font when using mouse wheel and holding <Kbd>{controlKeyLabel()}</Kbd> key
+                    </Text>
+                  )}
                   onChange={(_, val) => {
                     this.touchMonacoProperty('mouseWheelZoom', val)
                   }}

--- a/web/src/components/features/settings/SettingsModal.tsx
+++ b/web/src/components/features/settings/SettingsModal.tsx
@@ -136,6 +136,19 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
               }
             />
             <SettingsProperty
+              key="enableAutoSave"
+              title="Enable Auto Save"
+              control={
+                <Checkbox
+                  label="Restore last editor contents when playground opens"
+                  defaultChecked={this.props.settings?.autoSave}
+                  onChange={(_, val) => {
+                    this.touchSettingsProperty({ autoSave: val })
+                  }}
+                />
+              }
+            />
+            <SettingsProperty
               key="autoDetectTheme"
               title="Use System Theme"
               control={

--- a/web/src/components/features/settings/SettingsModal.tsx
+++ b/web/src/components/features/settings/SettingsModal.tsx
@@ -120,14 +120,14 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
               }
             />
             <SettingsProperty
-              key="minimap"
-              title="Mini Map"
+              key="enableVimMode"
+              title="Enable Vim Mode"
               control={
                 <Checkbox
-                  label="Enable mini map on side"
-                  defaultChecked={this.props.monaco?.minimap}
+                  label="Enables Vim motions in code editor"
+                  defaultChecked={this.props.settings?.enableVimMode}
                   onChange={(_, val) => {
-                    this.touchMonacoProperty('minimap', val)
+                    this.touchSettingsProperty({ enableVimMode: val })
                   }}
                 />
               }
@@ -137,7 +137,7 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
               title="Use System Theme"
               control={
                 <Checkbox
-                  label="Follow system dark mode preference instead of manual toggle."
+                  label="Match editor theme with system dark mode preference"
                   defaultChecked={this.props.settings?.useSystemTheme}
                   onChange={(_, val) => {
                     this.touchSettingsProperty({
@@ -161,14 +161,14 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
               }
             />
             <SettingsProperty
-              key="enableVimMode"
-              title="Enable Vim Mode"
+              key="mouseWheelZoom"
+              title="Mouse Wheel Zoom"
               control={
                 <Checkbox
-                  label="Allows usage of Vim key bindings when editing"
-                  defaultChecked={this.props.settings?.enableVimMode}
+                  label="Zoom the font in the editor when using the mouse wheel in combination with holding Ctrl / ⌘ key"
+                  defaultChecked={this.props.monaco?.mouseWheelZoom}
                   onChange={(_, val) => {
-                    this.touchSettingsProperty({ enableVimMode: val })
+                    this.touchMonacoProperty('mouseWheelZoom', val)
                   }}
                 />
               }
@@ -192,7 +192,7 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
             <SettingsProperty
               key="cursorStyle"
               title="Cursor Style"
-              description="Set the cursor style"
+              description="Controls the cursor style"
               control={
                 <Dropdown
                   options={cursorLineOptions}
@@ -204,8 +204,34 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
               }
             />
             <SettingsProperty
-              key="selectOnLineNumbers"
-              title="Select On Line Numbers"
+              key="smoothScroll"
+              title="Smooth Scrolling"
+              control={
+                <Checkbox
+                  label="Controls whether the editor will scroll using an animation"
+                  defaultChecked={this.props.monaco?.smoothScrolling}
+                  onChange={(_, val) => {
+                    this.touchMonacoProperty('smoothScrolling', val)
+                  }}
+                />
+              }
+            />
+            <SettingsProperty
+              key="minimap"
+              title="Mini Map"
+              control={
+                <Checkbox
+                  label="Controls whether the minimap is shown"
+                  defaultChecked={this.props.monaco?.minimap}
+                  onChange={(_, val) => {
+                    this.touchMonacoProperty('minimap', val)
+                  }}
+                />
+              }
+            />
+            <SettingsProperty
+              key="selectOnGutterClick"
+              title="Select On Gutter Click"
               control={
                 <Checkbox
                   label="Select corresponding line on line number click"
@@ -225,32 +251,6 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
                   defaultChecked={this.props.monaco?.contextMenu}
                   onChange={(_, val) => {
                     this.touchMonacoProperty('contextMenu', val)
-                  }}
-                />
-              }
-            />
-            <SettingsProperty
-              key="smoothScroll"
-              title="Smooth Scrolling"
-              control={
-                <Checkbox
-                  label="Enable that the editor animates scrolling to a position"
-                  defaultChecked={this.props.monaco?.smoothScrolling}
-                  onChange={(_, val) => {
-                    this.touchMonacoProperty('smoothScrolling', val)
-                  }}
-                />
-              }
-            />
-            <SettingsProperty
-              key="mouseWheelZoom"
-              title="Mouse Wheel Zoom"
-              control={
-                <Checkbox
-                  label="Zoom the font in the editor when using the mouse wheel in combination with holding Ctrl / ⌘ key"
-                  defaultChecked={this.props.monaco?.mouseWheelZoom}
-                  onChange={(_, val) => {
-                    this.touchMonacoProperty('mouseWheelZoom', val)
                   }}
                 />
               }

--- a/web/src/services/config/config.ts
+++ b/web/src/services/config/config.ts
@@ -9,6 +9,7 @@ import { type MonacoSettings, defaultMonacoSettings } from './monaco'
 
 const DARK_THEME_KEY = 'ui.darkTheme.enabled'
 const USE_SYSTEM_THEME_KEY = 'ui.darkTheme.useSystem'
+const AUTOSAVE_ENABLED = 'ui.autosave.enabled'
 const RUN_TARGET_KEY = 'go.build.target'
 const ENABLE_VIM_MODE_KEY = 'ms.monaco.vimModeEnabled'
 const AUTOFORMAT_KEY = 'go.build.autoFormat'
@@ -29,6 +30,14 @@ const Config = {
 
   set darkThemeEnabled(enable: boolean) {
     this.setBoolean(DARK_THEME_KEY, enable)
+  },
+
+  get autoSave() {
+    return this.getBoolean(AUTOSAVE_ENABLED, false)
+  },
+
+  set autoSave(val: boolean) {
+    this.setBoolean(AUTOSAVE_ENABLED, val)
   },
 
   get useSystemTheme() {

--- a/web/src/store/dispatchers/settings.ts
+++ b/web/src/store/dispatchers/settings.ts
@@ -12,6 +12,7 @@ import {
   newSettingsChangeAction,
   newToggleThemeAction,
 } from '../actions'
+import { saveWorkspaceState, truncateWorkspaceState } from '../workspace/config'
 
 export function newMonacoParamsChangeDispatcher(changes: MonacoParamsChanges): Dispatcher {
   return (dispatch: DispatchFn, _: StateProvider) => {
@@ -23,7 +24,7 @@ export function newMonacoParamsChangeDispatcher(changes: MonacoParamsChanges): D
 
 export const newSettingsChangeDispatcher =
   (changes: Partial<SettingsState>): Dispatcher =>
-  (dispatch: DispatchFn, _: StateProvider) => {
+  (dispatch: DispatchFn, getState: StateProvider) => {
     if ('useSystemTheme' in changes) {
       config.useSystemTheme = !!changes.useSystemTheme
       changes.darkMode = isDarkModeEnabled()
@@ -35,6 +36,20 @@ export const newSettingsChangeDispatcher =
 
     if ('enableVimMode' in changes) {
       config.enableVimMode = !!changes.enableVimMode
+    }
+
+    if ('autoSave' in changes) {
+      config.autoSave = !!changes.autoSave
+
+      // Immediately save workspace
+      if (changes.autoSave) {
+        const { workspace } = getState()
+        if (!workspace.snippet?.id) {
+          saveWorkspaceState(workspace)
+        }
+      } else {
+        truncateWorkspaceState()
+      }
     }
 
     dispatch(newSettingsChangeAction(changes))

--- a/web/src/store/reducers.ts
+++ b/web/src/store/reducers.ts
@@ -27,6 +27,7 @@ import { type SettingsState, type State, type StatusState, type PanelState, type
 
 // TODO: move settings reducers and state to store/settings
 const initialSettingsState: SettingsState = {
+  autoSave: config.autoSave,
   darkMode: config.darkThemeEnabled,
   autoFormat: true,
   useSystemTheme: config.useSystemTheme,

--- a/web/src/store/state.ts
+++ b/web/src/store/state.ts
@@ -25,6 +25,7 @@ export interface StatusState {
 export interface SettingsState {
   darkMode: boolean
   useSystemTheme: boolean
+  autoSave: boolean
   autoFormat: boolean
   enableVimMode: boolean
   goProxyUrl: string

--- a/web/src/store/workspace/config.ts
+++ b/web/src/store/workspace/config.ts
@@ -8,6 +8,20 @@ const defaultWorkspace: WorkspaceState = {
   files: defaultFiles,
 }
 
+const sanitizeState = (state: WorkspaceState) => {
+  // Skip current snippet URL.
+  const { selectedFile, files } = state
+
+  if (!files) {
+    // Save defaults if ws is empty.
+    return defaultWorkspace
+  }
+
+  return { selectedFile, files }
+}
+
+export const truncateWorkspaceState = () => config.delete(CONFIG_KEY)
+
 export const saveWorkspaceState = (state: WorkspaceState) => {
   const sanitized = sanitizeState(state)
   if (!sanitized.files || Object.keys(sanitized.files).length === 0) {
@@ -20,15 +34,3 @@ export const saveWorkspaceState = (state: WorkspaceState) => {
 }
 
 export const loadWorkspaceState = (): WorkspaceState => sanitizeState(config.getObject(CONFIG_KEY, defaultWorkspace))
-
-const sanitizeState = (state: WorkspaceState) => {
-  // Skip current snippet URL.
-  const { selectedFile, files } = state
-
-  if (!files) {
-    // Save defaults if ws is empty.
-    return defaultWorkspace
-  }
-
-  return { selectedFile, files }
-}

--- a/web/src/store/workspace/dispatchers/snippet.ts
+++ b/web/src/store/workspace/dispatchers/snippet.ts
@@ -12,6 +12,7 @@ import {
 import { newLoadingAction, newErrorAction, newUIStateChangeAction } from '~/store/actions/ui'
 import { type SnippetLoadPayload, WorkspaceAction, type BulkFileUpdatePayload } from '../actions'
 import { loadWorkspaceState } from '../config'
+import { getDefaultWorkspaceState } from '../state'
 
 /**
  * Dispatch snippet load from a predefined source.
@@ -54,9 +55,15 @@ export const dispatchLoadSnippetFromSource = (source: SnippetSource) => async (d
 export const dispatchLoadSnippet =
   (snippetId: string | null) => async (dispatch: DispatchFn, getState: StateProvider) => {
     if (!snippetId) {
+      const {
+        settings: { autoSave },
+        workspace: { snippet },
+      } = getState()
+
+      const shouldAutosave = autoSave && !snippet?.id
       dispatch({
         type: WorkspaceAction.WORKSPACE_IMPORT,
-        payload: loadWorkspaceState(),
+        payload: shouldAutosave ? loadWorkspaceState() : getDefaultWorkspaceState(),
       })
       return
     }

--- a/web/src/store/workspace/state.ts
+++ b/web/src/store/workspace/state.ts
@@ -59,3 +59,13 @@ export const initialWorkspaceState: WorkspaceState = {
 export const defaultFiles = {
   [defaultFileName]: defaultFile,
 }
+
+export const getDefaultWorkspaceState = (): WorkspaceState => ({
+  selectedFile: defaultFileName,
+  snippet: {
+    loading: false,
+  },
+  files: {
+    [defaultFileName]: defaultFile,
+  },
+})

--- a/web/src/utils/dom.ts
+++ b/web/src/utils/dom.ts
@@ -1,2 +1,11 @@
-export const isTouchDevice = () =>
-  'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0
+export const isTouchDevice = () => 'ontouchstart' in window || navigator.maxTouchPoints > 0
+
+export const isAppleDevice = () => /(iPad|iPhone|iPod|Mac)/g.test(navigator.userAgent)
+
+/**
+ * Returns name of a Ctrl or Command key label depending on user agent.
+ *
+ * Used to highlight shortcut key combinations.
+ * @returns
+ */
+export const controlKeyLabel = () => (isAppleDevice() ? '⌘' : 'Ctrl')


### PR DESCRIPTION
This PR disables autosave by default as this might be inconvenient for fast prototyping purposes.

Also settings were improved:
* Setting options were reordered to put most important features in the first tab.
* Description for editor font resize with mouse wheel option was improved.

Closes: #400 

![image](https://github.com/user-attachments/assets/70b1ebee-9332-4187-b99e-cf87fb1867b2)
