### PR TITLE
feat: fallback mode without xterm.js

### DIFF
--- a/web/src/components/features/inspector/Console/Console.tsx
+++ b/web/src/components/features/inspector/Console/Console.tsx
@@ -31,7 +31,7 @@ const config: ITerminalOptions = {
   convertEol: true,
 }
 
-interface Props {
+export interface ConsoleProps {
   status?: StatusState
   fontFamily: string
   fontSize: number
@@ -85,7 +85,7 @@ const CopyButton: React.FC<{
 /**
  * Console is Go program events output component based on xterm.js
  */
-export const Console: React.FC<Props> = ({ fontFamily, fontSize, status, backend }) => {
+export const Console: React.FC<ConsoleProps> = ({ fontFamily, fontSize, status, backend }) => {
   const theme = useXtermTheme()
   const [offset, setOffset] = useState(0)
   const [isFocused, setIsFocused] = useState(false)

--- a/web/src/components/features/inspector/FallbackOutput/FallbackOutput.tsx
+++ b/web/src/components/features/inspector/FallbackOutput/FallbackOutput.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+import { mergeStyleSets, useTheme } from '@fluentui/react'
+import type { StatusState } from '~/store'
+import { OutputLine } from './OutputLine'
+
+interface Props {
+  status?: StatusState
+  fontFamily: string
+  fontSize: number
+}
+
+/**
+ * Fallback console without terminal escape sequence emulation.
+ */
+export const FallbackOutput: React.FC<Props> = ({ fontFamily, fontSize, status }) => {
+  const theme = useTheme()
+  const styles = mergeStyleSets({
+    container: {
+      flex: '1 1 auto',
+      boxSizing: 'border-box',
+      padding: '0, 15px',
+    },
+    programExitMsg: {
+      marginTop: '1rem',
+      display: 'inline-block',
+      color: theme.semanticColors.disabledText,
+    },
+  })
+
+  return (
+    <div className={styles.container} style={{ fontFamily, fontSize: `${fontSize}px` }}>
+      {status?.events?.map((event, i) => <OutputLine key={i} event={event} />)}
+      {!status?.running && <span className={styles.programExitMsg}>Program exited.</span>}
+    </div>
+  )
+}

--- a/web/src/components/features/inspector/FallbackOutput/OutputLine.tsx
+++ b/web/src/components/features/inspector/FallbackOutput/OutputLine.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+import { mergeStyleSets } from '@fluentui/react'
+import type { EvalEvent } from '~/services/api'
+
+const imageSectionPrefix = 'IMAGE:'
+const base64RegEx = /^[A-Za-z0-9+/]+={0,2}$/
+
+const isImageLine = (message: string) => {
+  if (!message?.startsWith(imageSectionPrefix)) {
+    return [false, null]
+  }
+
+  const payload = message.substring(imageSectionPrefix.length).trim()
+  return [base64RegEx.test(payload), payload]
+}
+
+const styles = mergeStyleSets({
+  container: {
+    display: 'table',
+    width: '100%',
+    '&[data-event-kind="stderr"]': {
+      color: '#e22',
+    },
+  },
+  delay: {
+    color: '#666',
+    marginRight: '5px',
+    float: 'right',
+  },
+  message: {
+    font: 'inherit',
+    border: 'none',
+    margin: 0,
+    float: 'left',
+  },
+})
+
+interface Props {
+  event: EvalEvent
+}
+
+export const OutputLine: React.FC<Props> = ({ event }) => {
+  const [isImage, payload] = isImageLine(event.Message)
+
+  return (
+    <div className={styles.container} data-event-kind={event.Kind}>
+      {isImage ? (
+        <img src={`data:image;base64,${payload}`} alt="Image output" />
+      ) : (
+        <pre className={styles.message}>{event.Message}</pre>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/features/inspector/FallbackOutput/index.ts
+++ b/web/src/components/features/inspector/FallbackOutput/index.ts
@@ -1,0 +1,1 @@
+export * from './FallbackOutput'

--- a/web/src/components/features/inspector/InspectorPanel/InspectorPanel.tsx
+++ b/web/src/components/features/inspector/InspectorPanel/InspectorPanel.tsx
@@ -4,7 +4,7 @@ import { Resizable } from 're-resizable'
 import clsx from 'clsx'
 import { VscChevronDown, VscChevronUp, VscSplitHorizontal, VscSplitVertical } from 'react-icons/vsc'
 
-import { ConnectedRunOutput } from '../RunOutput'
+import { RunOutput } from '../RunOutput'
 import { PanelHeader } from '~/components/elements/panel/PanelHeader'
 import { LayoutType, DEFAULT_PANEL_HEIGHT, DEFAULT_PANEL_WIDTH_PERCENT } from '~/styles/layout'
 import './InspectorPanel.css'
@@ -148,7 +148,7 @@ export const InspectorPanel: React.FC<Props> = ({
         }}
       />
       <div className="InspectorPanel__container" hidden={isCollapsed}>
-        <ConnectedRunOutput />
+        <RunOutput />
       </div>
     </Resizable>
   )

--- a/web/src/components/features/settings/SettingsModal.tsx
+++ b/web/src/components/features/settings/SettingsModal.tsx
@@ -8,21 +8,21 @@ import {
   MessageBarType,
   PivotItem,
   Text,
-  TextField
+  TextField,
 } from '@fluentui/react'
 
-import {AnimatedPivot} from '~/components/elements/tabs/AnimatedPivot'
-import {ThemeableComponent} from '~/components/utils/ThemeableComponent'
-import {Dialog} from '~/components/elements/modals/Dialog'
-import {SettingsProperty} from './SettingsProperty'
-import {DEFAULT_FONT} from '~/services/fonts'
-import type {MonacoSettings} from '~/services/config'
-import type {RenderingBackend, TerminalSettings} from '~/store/terminal'
-import {connect, type MonacoParamsChanges, type SettingsState, type StateDispatch} from '~/store'
+import { AnimatedPivot } from '~/components/elements/tabs/AnimatedPivot'
+import { ThemeableComponent } from '~/components/utils/ThemeableComponent'
+import { Dialog } from '~/components/elements/modals/Dialog'
+import { SettingsProperty } from './SettingsProperty'
+import { DEFAULT_FONT } from '~/services/fonts'
+import type { MonacoSettings } from '~/services/config'
+import type { RenderingBackend, TerminalSettings } from '~/store/terminal'
+import { connect, type MonacoParamsChanges, type SettingsState, type StateDispatch } from '~/store'
 
-import {cursorBlinkOptions, cursorLineOptions, fontOptions, terminalBackendOptions} from './options'
-import {controlKeyLabel} from '~/utils/dom'
-import {Kbd} from '~/components/elements/misc/Kbd'
+import { cursorBlinkOptions, cursorLineOptions, fontOptions, terminalBackendOptions } from './options'
+import { controlKeyLabel } from '~/utils/dom'
+import { Kbd } from '~/components/elements/misc/Kbd'
 
 export interface SettingsChanges {
   monaco?: MonacoParamsChanges
@@ -371,7 +371,9 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
             />
             <div hidden={!this.state.hideTerminalSettings}>
               <MessageBar messageBarType={MessageBarType.warning}>
-                Colored text, screen clear and other features relying on terminal escape sequences will not work.
+                <span>Colored text, screen clear and other features relying on terminal escape sequences require </span>
+                <u>Emulate Terminal</u>
+                <span> option to be enabled.</span>
               </MessageBar>
             </div>
           </PivotItem>

--- a/web/src/components/features/settings/SettingsModal.tsx
+++ b/web/src/components/features/settings/SettingsModal.tsx
@@ -338,21 +338,6 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
               }
             />
             <SettingsProperty
-              key="termEmulationEnabled"
-              title="Emulate Terminal"
-              control={
-                <Checkbox
-                  label="Disable this option if you have troubles copying output text."
-                  defaultChecked={!this.props.terminal?.disableTerminalEmulation}
-                  onChange={(_, val) => {
-                    this.touchTerminalSettings({
-                      disableTerminalEmulation: !val,
-                    })
-                  }}
-                />
-              }
-            />
-            <SettingsProperty
               key="terminalBackend"
               title="Rendering Backend"
               description="Set the rendering backend for the terminal."
@@ -369,11 +354,24 @@ class SettingsModal extends ThemeableComponent<Props, SettingsModalState> {
                 />
               }
             />
-            <div hidden={!this.state.hideTerminalSettings}>
+            <SettingsProperty
+              key="termEmulationEnabled"
+              title="Emulate Terminal"
+              control={
+                <Checkbox
+                  label="Enables ANSI terminal escape sequences support using xterm.js."
+                  defaultChecked={!this.props.terminal?.disableTerminalEmulation}
+                  onChange={(_, val) => {
+                    this.touchTerminalSettings({
+                      disableTerminalEmulation: !val,
+                    })
+                  }}
+                />
+              }
+            />
+            <div>
               <MessageBar messageBarType={MessageBarType.warning}>
-                <span>Colored text, screen clear and other features relying on terminal escape sequences require </span>
-                <u>Emulate Terminal</u>
-                <span> option to be enabled.</span>
+                Disable <u>Emulate Terminal</u> feature if you having troubles copying text from output.
               </MessageBar>
             </div>
           </PivotItem>

--- a/web/src/store/terminal/types.ts
+++ b/web/src/store/terminal/types.ts
@@ -7,6 +7,7 @@ export enum RenderingBackend {
 export interface TerminalSettings {
   fontSize: number
   renderingBackend: RenderingBackend
+  disableTerminalEmulation?: boolean
 }
 
 export const defaultTerminalSettings: TerminalSettings = {


### PR DESCRIPTION
This PR adds option to disable xterm.js and use a simple HTML output renderer.

Created to address https://github.com/x1unix/go-playground/issues/461