### PR TITLE
fix: set correct whitespace in output

### DIFF
--- a/web/src/components/features/inspector/FallbackOutput/OutputLine.tsx
+++ b/web/src/components/features/inspector/FallbackOutput/OutputLine.tsx
@@ -33,6 +33,7 @@ const styles = mergeStyleSets({
     border: 'none',
     margin: 0,
     float: 'left',
+    whiteSpace: 'pre-wrap',
   },
 })
 


### PR DESCRIPTION
Set `white-space: pre-wrap` to wrap text in output