### PR TITLE
feat: support runtime.wasmWrite

### DIFF
--- a/web/src/workers/go/go.worker.ts
+++ b/web/src/workers/go/go.worker.ts
@@ -33,6 +33,7 @@ class WorkerHandler implements GoExecutor {
 
     const go = new GoWrapper(new globalThis.Go(), {
       globalValue: wrapGlobal(mocks, globalThis),
+      stdoutHandler: fs,
     })
 
     const { instance } = await WebAssembly.instantiate(image, go.importObject)


### PR DESCRIPTION
In recent Go versions, Go started using `runtime.wasmWrite` to dump panics and stderr.