### PR TITLE
docs: fix indefinite article and add https scheme to Discussions links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 * **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/x1unix/go-playground/issues).
 
-* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/x1unix/go-playground/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **shared code snippet** demonstrating the expected behavior that is not occurring.
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/x1unix/go-playground/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or a **shared code snippet** demonstrating the expected behavior that is not occurring.
 
 ## Did you write a patch that fixes a bug?
 
@@ -14,7 +14,7 @@
 
 ## Do you intend to add a new feature or change an existing one?
 
-* Suggest your change in the [Discussions](github.com/x1unix/go-playground/discussions) section and start writing code.
+* Suggest your change in the [Discussions](https://github.com/x1unix/go-playground/discussions) section and start writing code.
 
 * Do not open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
 
@@ -22,7 +22,7 @@
 
 * Please see [HACKING.md](HACKING.md) for a project development guide.
 
-* Ask any question about code structure in the [Discussions](github.com/x1unix/go-playground/discussions) section.
+* Ask any question about code structure in the [Discussions](https://github.com/x1unix/go-playground/discussions) section.
 
 This project is a volunteer effort. We encourage you to pitch in and join [the team](https://github.com/x1unix/go-playground/graphs/contributors)!
 


### PR DESCRIPTION
## Description
This PR fixes link URLs and grammar in `CONTRIBUTING.md`.

## Details
1. Fixed `an shared code snippet` -> `a shared code snippet`.
2. Added missing `https://` scheme to Discussions links to prevent relative URL resolution.